### PR TITLE
Feat(Problem): 문제 세트 조회 API 구현 (SWM-45)

### DIFF
--- a/jabiseo-api/src/main/java/com/jabiseo/problem/controller/ProblemController.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/problem/controller/ProblemController.java
@@ -14,6 +14,7 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.net.URI;
 import java.util.List;
+import java.util.Optional;
 
 @RestController
 @RequiredArgsConstructor
@@ -30,7 +31,7 @@ public class ProblemController {
     public ResponseEntity<List<FindProblemsResponse>> findProblems(
             @RequestParam(name = "certificate-id") String certificateId,
             @RequestParam(name = "subject-id") List<String> subjectIds,
-            @RequestParam(name = "exam-id", required = false) String examId,
+            @RequestParam(name = "exam-id", required = false) Optional<String> examId,
             @RequestParam(required = false) int count
     ) {
         List<FindProblemsResponse> result =

--- a/jabiseo-api/src/main/java/com/jabiseo/problem/controller/ProblemController.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/problem/controller/ProblemController.java
@@ -28,12 +28,13 @@ public class ProblemController {
 
     @GetMapping("/set")
     public ResponseEntity<List<FindProblemsResponse>> findProblems(
-            @RequestParam(name = "certificate-id", required = false) String certificateId,
-            @RequestParam(name = "subject-id", required = false) String subjectId,
+            @RequestParam(name = "certificate-id") String certificateId,
+            @RequestParam(name = "subject-id") List<String> subjectIds,
             @RequestParam(name = "exam-id", required = false) String examId,
             @RequestParam(required = false) int count
     ) {
-        List<FindProblemsResponse> result = findProblemsUseCase.execute(certificateId, subjectId, examId, count);
+        List<FindProblemsResponse> result =
+                findProblemsUseCase.execute(certificateId, subjectIds, examId, count);
         return ResponseEntity.ok(result);
     }
 

--- a/jabiseo-api/src/main/java/com/jabiseo/problem/dto/ChoiceResponse.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/problem/dto/ChoiceResponse.java
@@ -1,6 +1,17 @@
 package com.jabiseo.problem.dto;
 
+import java.util.List;
+
 public record ChoiceResponse(
         String choice
 ) {
+    public static ChoiceResponse from(String choice) {
+        return new ChoiceResponse(choice);
+    }
+
+    public static List<ChoiceResponse> fromChoices(List<String> choices) {
+        return choices.stream()
+                .map(ChoiceResponse::from)
+                .toList();
+    }
 }

--- a/jabiseo-api/src/main/java/com/jabiseo/problem/dto/CreateReportRequest.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/problem/dto/CreateReportRequest.java
@@ -1,6 +1,6 @@
 package com.jabiseo.problem.dto;
 
-import com.jabiseo.problem.ReportType;
+import com.jabiseo.problem.domain.ReportType;
 
 public record CreateReportRequest(
         String problemId,

--- a/jabiseo-api/src/main/java/com/jabiseo/problem/dto/FindProblemsResponse.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/problem/dto/FindProblemsResponse.java
@@ -2,6 +2,7 @@ package com.jabiseo.problem.dto;
 
 import com.jabiseo.certificate.dto.ExamResponse;
 import com.jabiseo.certificate.dto.SubjectResponse;
+import com.jabiseo.problem.domain.Problem;
 
 import java.util.List;
 
@@ -16,4 +17,17 @@ public record FindProblemsResponse(
         String theory,
         String solution
 ) {
+    public static FindProblemsResponse from(Problem problem) {
+        return new FindProblemsResponse(
+                problem.getId(),
+                ExamResponse.from(problem.getExam()),
+                SubjectResponse.from(problem.getSubject()),
+                false, // TODO: 로그인 기능 구현 후 수정
+                problem.getDescription(),
+                ChoiceResponse.fromChoices(problem.getChoices()),
+                problem.getAnswerNumber(),
+                problem.getTheory(),
+                problem.getSolution()
+        );
+    }
 }

--- a/jabiseo-api/src/main/java/com/jabiseo/problem/usecase/FindProblemsUseCase.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/problem/usecase/FindProblemsUseCase.java
@@ -80,17 +80,17 @@ public class FindProblemsUseCase {
         });
     }
 
-    private static void validateProblemCount(int count) {
-        // 문제의 개수가 올바른지 검사
-        if (count < MIN_PROBLEM_PER_SUBJECT_COUNT || count > MAX_PROBLEM_PER_SUBJECT_COUNT) {
-            throw new ProblemBusinessException(ProblemErrorCode.INVALID_PROBLEM_COUNT);
-        }
-    }
-
     private static void validateExamId(Optional<String> examId, Certificate certificate) {
         // 자격증에 해당하는 시험이 있는지 검사j
         if (examId.isPresent() && !certificate.containsExam(examId.get())) {
             throw new CertificateBusinessException(CertificateErrorCode.EXAM_NOT_FOUND_IN_CERTIFICATE);
+        }
+    }
+
+    private static void validateProblemCount(int count) {
+        // 문제의 개수가 올바른지 검사
+        if (count < MIN_PROBLEM_PER_SUBJECT_COUNT || count > MAX_PROBLEM_PER_SUBJECT_COUNT) {
+            throw new ProblemBusinessException(ProblemErrorCode.INVALID_PROBLEM_COUNT);
         }
     }
 }

--- a/jabiseo-api/src/main/java/com/jabiseo/problem/usecase/FindProblemsUseCase.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/problem/usecase/FindProblemsUseCase.java
@@ -1,32 +1,58 @@
 package com.jabiseo.problem.usecase;
 
+import com.jabiseo.certificate.domain.Certificate;
+import com.jabiseo.certificate.domain.CertificateRepository;
 import com.jabiseo.certificate.dto.ExamResponse;
 import com.jabiseo.certificate.dto.SubjectResponse;
+import com.jabiseo.certificate.exception.CertificateBusinessException;
+import com.jabiseo.certificate.exception.CertificateErrorCode;
+import com.jabiseo.problem.domain.ProblemRepository;
 import com.jabiseo.problem.dto.ChoiceResponse;
 import com.jabiseo.problem.dto.FindProblemsRequest;
 import com.jabiseo.problem.dto.FindProblemsResponse;
+import com.jabiseo.problem.exception.ProblemBusinessException;
+import com.jabiseo.problem.exception.ProblemErrorCode;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
 public class FindProblemsUseCase {
 
-    public List<FindProblemsResponse> execute(String certificateId, String subjectId, String examId, int count) {
-        return new ArrayList<>(List.of(
-                new FindProblemsResponse(
-                        "1",
-                        new ExamResponse("examId", "examDescription"),
-                        new SubjectResponse("subjectId", 3, "subjectName"),
-                        true,
-                        "description",
-                        List.of(new ChoiceResponse("choice")),
-                        1,
-                        "theory",
-                        "solution"
-                )
-        ));
+    private static final int MIN_PROBLEM_PER_SUBJECT_COUNT = 0;
+    private static final int MAX_PROBLEM_PER_SUBJECT_COUNT = 20;
+
+
+    private final CertificateRepository certificateRepository;
+
+    private final ProblemRepository problemRepository;
+
+    public List<FindProblemsResponse> execute(String certificateId, List<String> subjectIds, String examId, int count) {
+        Certificate certificate = certificateRepository.findById(certificateId)
+                .orElseThrow(() -> new CertificateBusinessException(CertificateErrorCode.CERTIFICATE_NOT_FOUND));
+
+        // TODO: 검증을 어디서 어떻게 할 것인지 논의 필요
+        validateSubjectIds(subjectIds, certificate);
+        validateExamId(examId, certificate);
+        validateProblemCount(count);
+
+        if (examId != null) {
+            return subjectIds.stream()
+                    .map(subjectId -> problemRepository.findRandomByExamIdAndSubjectId(examId, subjectId, count))
+                    .flatMap(List::stream)
+                    .map(FindProblemsResponse::from)
+                    .toList();
+        }
+        return subjectIds.stream()
+                .map(subjectId -> problemRepository.findRandomBySubjectId(subjectId, count))
+                .flatMap(List::stream)
+                .map(FindProblemsResponse::from)
+                .toList();
     }
 
     public List<FindProblemsResponse> execute(FindProblemsRequest request) {
@@ -43,5 +69,28 @@ public class FindProblemsUseCase {
                         "solution"
                 )
         ));
+    }
+
+    private static void validateSubjectIds(List<String> subjectIds, Certificate certificate) {
+        // 자격증에 해당하는 과목들이 모두 있는지 검사
+        subjectIds.forEach(subjectId -> {
+            if (!certificate.containsSubject(subjectId)) {
+                throw new CertificateBusinessException(CertificateErrorCode.SUBJECT_NOT_FOUND_IN_CERTIFICATE);
+            }
+        });
+    }
+
+    private static void validateProblemCount(int count) {
+        // 문제의 개수가 올바른지 검사
+        if (count < MIN_PROBLEM_PER_SUBJECT_COUNT || count > MAX_PROBLEM_PER_SUBJECT_COUNT) {
+            throw new ProblemBusinessException(ProblemErrorCode.INVALID_PROBLEM_COUNT);
+        }
+    }
+
+    private static void validateExamId(String examId, Certificate certificate) {
+        // 자격증에 해당하는 시험이 있는지 검사
+        if (examId != null && !certificate.containsExam(examId)) {
+            throw new CertificateBusinessException(CertificateErrorCode.EXAM_NOT_FOUND_IN_CERTIFICATE);
+        }
     }
 }

--- a/jabiseo-api/src/test/java/com/jabiseo/fixture/ProblemFixture.java
+++ b/jabiseo-api/src/test/java/com/jabiseo/fixture/ProblemFixture.java
@@ -1,0 +1,26 @@
+package com.jabiseo.fixture;
+
+import com.jabiseo.certificate.domain.Certificate;
+import com.jabiseo.certificate.domain.Exam;
+import com.jabiseo.certificate.domain.Subject;
+import com.jabiseo.problem.domain.Problem;
+
+public class ProblemFixture {
+    public static Problem createProblem(String id, Certificate certificate, Exam exam, Subject subject) {
+        return Problem.of(
+                id,
+                "problem description",
+                "choice1",
+                "choice2",
+                "choice3",
+                "choice4",
+                "choice5",
+                1,
+                "problem theory",
+                "problem solution",
+                certificate,
+                exam,
+                subject
+        );
+    }
+}

--- a/jabiseo-api/src/test/java/com/jabiseo/problem/usecase/FindProblemsUseCaseTest.java
+++ b/jabiseo-api/src/test/java/com/jabiseo/problem/usecase/FindProblemsUseCaseTest.java
@@ -1,0 +1,197 @@
+package com.jabiseo.problem.usecase;
+
+import com.jabiseo.certificate.domain.Certificate;
+import com.jabiseo.certificate.domain.CertificateRepository;
+import com.jabiseo.certificate.domain.Exam;
+import com.jabiseo.certificate.domain.Subject;
+import com.jabiseo.certificate.exception.CertificateBusinessException;
+import com.jabiseo.certificate.exception.CertificateErrorCode;
+import com.jabiseo.problem.domain.Problem;
+import com.jabiseo.problem.domain.ProblemRepository;
+import com.jabiseo.problem.dto.FindProblemsResponse;
+import com.jabiseo.problem.exception.ProblemBusinessException;
+import com.jabiseo.problem.exception.ProblemErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.jabiseo.fixture.CertificateFixture.createCertificate;
+import static com.jabiseo.fixture.ExamFixture.createExam;
+import static com.jabiseo.fixture.ProblemFixture.createProblem;
+import static com.jabiseo.fixture.SubjectFixture.createSubject;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+@DisplayName("문제 세트 조회 테스트")
+@ExtendWith(MockitoExtension.class)
+class FindProblemsUseCaseTest {
+
+    @InjectMocks
+    FindProblemsUseCase sut;
+
+    @Mock
+    CertificateRepository certificateRepository;
+
+    @Mock
+    ProblemRepository problemRepository;
+
+    @Test
+    @DisplayName("시험 조건이 있는 문제 세트 조회 테스트 성공 케이스")
+    void givenIdsIncludeExamIdAndCount_whenFindingProblems_then() {
+        //given
+        String certificateId = "1";
+        String[] subjectIds = {"2", "3"};
+        String examId = "4";
+        String[] problemIds = {"5", "6", "7"};
+        int count = 4;
+        Certificate certificate = createCertificate(certificateId);
+        Subject subject1 = createSubject(subjectIds[0], certificate);
+        Subject subject2 = createSubject(subjectIds[1], certificate);
+        Exam exam = createExam(examId, certificate);
+        List<Problem> problems = List.of(
+                createProblem(problemIds[0], certificate, exam, subject1),
+                createProblem(problemIds[1], certificate, exam, subject2),
+                createProblem(problemIds[2], certificate, exam, subject1)
+        );
+        given(certificateRepository.findById(certificateId)).willReturn(Optional.of(certificate));
+        given(problemRepository.findRandomByExamIdAndSubjectId(examId, subjectIds[0], count))
+                .willReturn(List.of(problems.get(0), problems.get(2)));
+        given(problemRepository.findRandomByExamIdAndSubjectId(examId, subjectIds[1], count))
+                .willReturn(List.of(problems.get(1)));
+
+        //when
+        List<FindProblemsResponse> result = sut.execute(certificateId, List.of(subjectIds), Optional.of(examId), count);
+
+        //then
+        assertThat(result).hasSize(3);
+        assertThat(result.get(0).problemId()).isEqualTo(problemIds[0]);
+        assertThat(result.get(1).problemId()).isEqualTo(problemIds[2]);
+        assertThat(result.get(2).problemId()).isEqualTo(problemIds[1]);
+    }
+
+    @Test
+    @DisplayName("시험 조건이 없는 문제 세트 조회 테스트 성공 케이스")
+    void givenIdsExcludeExamIdAndCount_whenFindingProblems_then() {
+        //given
+        String certificateId = "1";
+        String[] subjectIds = {"2", "3"};
+        String[] examIds = {"4", "8"};
+        String[] problemIds = {"5", "6", "7"};
+        int count = 4;
+        Certificate certificate = createCertificate(certificateId);
+        Subject subject1 = createSubject(subjectIds[0], certificate);
+        Subject subject2 = createSubject(subjectIds[1], certificate);
+        Exam exam1 = createExam(examIds[0], certificate);
+        Exam exam2 = createExam(examIds[1], certificate);
+        List<Problem> problems = List.of(
+                createProblem(problemIds[0], certificate, exam1, subject1),
+                createProblem(problemIds[1], certificate, exam2, subject2),
+                createProblem(problemIds[2], certificate, exam2, subject1)
+        );
+        given(certificateRepository.findById(certificateId)).willReturn(Optional.of(certificate));
+        given(problemRepository.findRandomBySubjectId(subjectIds[0], count))
+                .willReturn(List.of(problems.get(0), problems.get(2)));
+        given(problemRepository.findRandomBySubjectId(subjectIds[1], count))
+                .willReturn(List.of(problems.get(1)));
+
+        //when
+        List<FindProblemsResponse> result = sut.execute(certificateId, List.of(subjectIds), Optional.empty(), count);
+
+        //then
+        assertThat(result).hasSize(3);
+        assertThat(result.get(0).problemId()).isEqualTo(problemIds[0]);
+        assertThat(result.get(1).problemId()).isEqualTo(problemIds[2]);
+        assertThat(result.get(2).problemId()).isEqualTo(problemIds[1]);
+    }
+
+    @Test
+    @DisplayName("문제 세트 조회 시 자격증이 존재하지 않는 경우")
+    void givenInvalidCertificate_whenFindingProblems_thenReturnError() throws Exception {
+        //given
+        String certificateId = "1";
+        String subjectId = "2";
+        String examId = "3";
+        int count = 4;
+        given(certificateRepository.findById(anyString())).willReturn(Optional.empty());
+
+        //when & then
+        assertThatThrownBy(() -> sut.execute(certificateId, List.of(subjectId), Optional.of(examId), count))
+                .isInstanceOf(CertificateBusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", CertificateErrorCode.CERTIFICATE_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("문제 세트 조회 시 자격증에 과목들이 하나라도 매칭되지 않는 경우")
+    void givenNotMatchingCertificateIdAndSubjectId_whenFindProblems_thenReturnError() throws Exception {
+        //given
+        String[] certificateIds = {"1", "8"};
+        String[] subjectIds = {"2", "3"};
+        String examId = "4";
+        int count = 4;
+        Certificate certificate1 = createCertificate(certificateIds[0]);
+        Certificate certificate2 = createCertificate(certificateIds[1]);
+        createSubject(subjectIds[0], certificate1);
+        createSubject(subjectIds[1], certificate2);
+        given(certificateRepository.findById(certificateIds[0])).willReturn(Optional.of(certificate1));
+
+
+        //when & then
+        assertThatThrownBy(() -> sut.execute(certificateIds[0], List.of(subjectIds), Optional.of(examId), count))
+                .isInstanceOf(CertificateBusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", CertificateErrorCode.SUBJECT_NOT_FOUND_IN_CERTIFICATE);
+    }
+
+    @Test
+    @DisplayName("문제 세트 조회 시 자격증에 시험이 매칭되지 않는 경우")
+    void givenNotMatchingCertificateIdAndExamId_whenFindProblems_thenReturnError() throws Exception {
+        //given
+        String[] certificateIds = {"1", "8"};
+        String subjectId = "2";
+        String examId = "4";
+        int count = 4;
+        Certificate certificate1 = createCertificate(certificateIds[0]);
+        Certificate certificate2 = createCertificate(certificateIds[1]);
+        createExam(examId, certificate2);
+        createSubject(subjectId, certificate1);
+
+        given(certificateRepository.findById(certificateIds[0])).willReturn(Optional.of(certificate1));
+
+
+        //when & then
+        assertThatThrownBy(() -> sut.execute(certificateIds[0], List.of(subjectId), Optional.of(examId), count))
+                .isInstanceOf(CertificateBusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", CertificateErrorCode.EXAM_NOT_FOUND_IN_CERTIFICATE);
+    }
+
+    @Test
+    @DisplayName("문제 세트 조회 시 과목당 문제 수가 0 이하이거나 20 초과인 경우")
+    void givenInvalidCount_whenFindProblems_thenReturnError() throws Exception {
+        //given
+        String certificateId = "1";
+        String subjectId = "2";
+        String examId = "3";
+        int count1 = -2;
+        int count2 = 21;
+        Certificate certificate = createCertificate(certificateId);
+        createSubject(subjectId, certificate);
+        createExam(examId, certificate);
+        given(certificateRepository.findById(certificateId)).willReturn(Optional.of(certificate));
+
+        //when & then
+        assertThatThrownBy(() -> sut.execute(certificateId, List.of(subjectId), Optional.of(examId), count1))
+                .isInstanceOf(ProblemBusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ProblemErrorCode.INVALID_PROBLEM_COUNT);
+        assertThatThrownBy(() -> sut.execute(certificateId, List.of(subjectId), Optional.of(examId), count2))
+                .isInstanceOf(ProblemBusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ProblemErrorCode.INVALID_PROBLEM_COUNT);
+    }
+
+}

--- a/jabiseo-domain/src/main/java/com/jabiseo/certificate/domain/Certificate.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/certificate/domain/Certificate.java
@@ -46,4 +46,15 @@ public class Certificate {
         subjects.add(subject);
     }
 
+    public boolean containsSubject(String subjectId) {
+        return subjects.stream()
+                .map(Subject::getId)
+                .anyMatch(id -> id.equals(subjectId));
+    }
+
+    public boolean containsExam(String examId) {
+        return exams.stream()
+                .map(Exam::getId)
+                .anyMatch(id -> id.equals(examId));
+    }
 }

--- a/jabiseo-domain/src/main/java/com/jabiseo/certificate/exception/CertificateErrorCode.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/certificate/exception/CertificateErrorCode.java
@@ -7,6 +7,8 @@ import lombok.Getter;
 public enum CertificateErrorCode implements ErrorCode {
 
     CERTIFICATE_NOT_FOUND("자격증을 찾을 수 없습니다.", "CER_001", ErrorCode.NOT_FOUND),
+    SUBJECT_NOT_FOUND_IN_CERTIFICATE("자격증에서 해당 과목을 찾을 수 없습니다.", "CER_002", ErrorCode.NOT_FOUND),
+    EXAM_NOT_FOUND_IN_CERTIFICATE("자격증에서 해당 시험을 찾을 수 없습니다.", "CER_003", ErrorCode.NOT_FOUND),
     ;
 
 

--- a/jabiseo-domain/src/main/java/com/jabiseo/problem/domain/Problem.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/problem/domain/Problem.java
@@ -54,4 +54,29 @@ public class Problem {
                 .filter((choice) -> choice != null && !choice.isBlank())
                 .toList();
     }
+
+    public Problem(String id, String description, String choice1, String choice2, String choice3,
+                   String choice4, String choice5, int answerNumber, String theory, String solution,
+                   Certificate certificate, Exam exam, Subject subject) {
+        this.id = id;
+        this.description = description;
+        this.choice1 = choice1;
+        this.choice2 = choice2;
+        this.choice3 = choice3;
+        this.choice4 = choice4;
+        this.choice5 = choice5;
+        this.answerNumber = answerNumber;
+        this.theory = theory;
+        this.solution = solution;
+        this.certificate = certificate;
+        this.exam = exam;
+        this.subject = subject;
+    }
+
+    public static Problem of(String id, String description, String choice1, String choice2, String choice3,
+                             String choice4, String choice5, int answerNumber, String theory, String solution,
+                             Certificate certificate, Exam exam, Subject subject) {
+        return new Problem(id, description, choice1, choice2, choice3, choice4, choice5,
+                answerNumber, theory, solution, certificate, exam, subject);
+    }
 }

--- a/jabiseo-domain/src/main/java/com/jabiseo/problem/domain/Problem.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/problem/domain/Problem.java
@@ -1,0 +1,57 @@
+package com.jabiseo.problem.domain;
+
+import com.jabiseo.certificate.domain.Certificate;
+import com.jabiseo.certificate.domain.Exam;
+import com.jabiseo.certificate.domain.Subject;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+public class Problem {
+
+    @Id
+    @Column(name = "problem_id")
+    private String id;
+
+    private String description;
+
+    private String choice1;
+
+    private String choice2;
+
+    private String choice3;
+
+    private String choice4;
+
+    private String choice5;
+
+    private int answerNumber;
+
+    private String theory;
+
+    private String solution;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "certificate_id", foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
+    private Certificate certificate;
+
+    @ManyToOne(fetch = FetchType.EAGER) // TODO: 문제 조회 시 항상 필요해서 일단 EAGER로 설정. 논의 필요
+    @JoinColumn(name = "exam_id", foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
+    private Exam exam;
+
+    @ManyToOne(fetch = FetchType.EAGER) // TODO: 문제 조회 시 항상 필요해서 일단 EAGER로 설정. 논의 필요
+    @JoinColumn(name = "subject_id", foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
+    private Subject subject;
+
+    public List<String> getChoices() {
+        return Stream.of(choice1, choice2, choice3, choice4, choice5)
+                .filter((choice) -> choice != null && !choice.isBlank())
+                .toList();
+    }
+}

--- a/jabiseo-domain/src/main/java/com/jabiseo/problem/domain/ProblemRepository.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/problem/domain/ProblemRepository.java
@@ -1,0 +1,15 @@
+package com.jabiseo.problem.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface ProblemRepository extends JpaRepository<Problem, String> {
+
+    @Query(value = "select * from problem where exam_id = :examId and subject_id = :subjectId order by rand() limit :count", nativeQuery = true)
+    List<Problem> findRandomByExamIdAndSubjectId(String examId, String subjectId, int count);
+
+    @Query(value = "select * from problem where subject_id = :subjectId order by rand() limit :count", nativeQuery = true)
+    List<Problem> findRandomBySubjectId(String subjectId, int count);
+}

--- a/jabiseo-domain/src/main/java/com/jabiseo/problem/domain/ReportType.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/problem/domain/ReportType.java
@@ -1,4 +1,4 @@
-package com.jabiseo.problem;
+package com.jabiseo.problem.domain;
 
 public enum ReportType {
     PROBLEM,

--- a/jabiseo-domain/src/main/java/com/jabiseo/problem/exception/ProblemBusinessException.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/problem/exception/ProblemBusinessException.java
@@ -1,0 +1,12 @@
+package com.jabiseo.problem.exception;
+
+import com.jabiseo.exception.BusinessException;
+import com.jabiseo.exception.ErrorCode;
+
+public class ProblemBusinessException extends BusinessException {
+
+    public ProblemBusinessException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+}

--- a/jabiseo-domain/src/main/java/com/jabiseo/problem/exception/ProblemErrorCode.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/problem/exception/ProblemErrorCode.java
@@ -1,0 +1,22 @@
+package com.jabiseo.problem.exception;
+
+import com.jabiseo.exception.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public enum ProblemErrorCode implements ErrorCode {
+
+    PROBLEM_NOT_FOUND("문제를 찾을 수 없습니다.", "PRO_001", ErrorCode.NOT_FOUND),
+    INVALID_PROBLEM_COUNT("문제의 개수가 올바르지 않습니다.", "PRO_002", ErrorCode.BAD_REQUEST);
+
+
+    private final String message;
+    private final String errorCode;
+    private final int statusCode;
+
+    ProblemErrorCode(String message, String errorCode, int statusCode) {
+        this.message = message;
+        this.errorCode = errorCode;
+        this.statusCode = statusCode;
+    }
+}


### PR DESCRIPTION
## PR 변경된 내용
- 문제 조회 API 가 기존에 과목 ID를 하나만 받는 문제 수정
- 문제 조회 시 examId는 required = false 이므로 깔끔한 처리를 위해 Optional로 요청받는 것으로 변경.
- Problem Entity 구현
- Problem에서 Exam과 Subject는 문제를 가져올 때마다 항상 가져와야 하기 때문에 FetchType.EAGER 로 설정. 가져오지 않는 경우의 존재 여부나 코드 스멜 등에서는 추후 논의
- 문제 랜덤 조회 쿼리는 native query로 구현. RAND()을 jpql이나 jpa에서 지원하지 않기 때문. 하지만 성능이 좋지 않음. 추후 논의해야 할 쿼리
- 이와 관련된 글 : https://dazbee.tistory.com/49
- 조회 API와 관련한 테스트 코드 구현


## 추가 내용

## 참조

Jira Issue: SWM-45
