### PR TITLE
Feat(Problem): Bookmark 생성,삭제 API 구현 (SWM-36)

### DIFF
--- a/jabiseo-api/src/main/java/com/jabiseo/problem/controller/BookmarkController.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/problem/controller/BookmarkController.java
@@ -24,7 +24,8 @@ public class BookmarkController {
     public ResponseEntity<Void> createBookmark(
             @RequestBody CreateBookmarkRequest request
     ) {
-        String bookmarkId = createBookmarkUseCase.execute(request);
+        String memberId = "1";
+        String bookmarkId = createBookmarkUseCase.execute(memberId, request);
 
         URI location = ServletUriComponentsBuilder
                 .fromCurrentRequest()

--- a/jabiseo-api/src/main/java/com/jabiseo/problem/controller/BookmarkController.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/problem/controller/BookmarkController.java
@@ -24,7 +24,7 @@ public class BookmarkController {
     public ResponseEntity<Void> createBookmark(
             @RequestBody CreateBookmarkRequest request
     ) {
-        String memberId = "1";
+        String memberId = "1"; // TODO : 로그인 기능 구현 후 로그인한 사용자의 ID로 변경
         String bookmarkId = createBookmarkUseCase.execute(memberId, request);
 
         URI location = ServletUriComponentsBuilder
@@ -40,7 +40,8 @@ public class BookmarkController {
     public ResponseEntity<Void> deleteBookmark(
             @RequestBody DeleteBookmarkRequest request
     ) {
-        deleteBookmarkUseCase.execute(request);
+        String memberId = "1"; // TODO : 로그인 기능 구현 후 로그인한 사용자의 ID로 변경
+        deleteBookmarkUseCase.execute(memberId, request);
         return ResponseEntity.noContent().build();
     }
 }

--- a/jabiseo-api/src/main/java/com/jabiseo/problem/usecase/CreateBookmarkUseCase.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/problem/usecase/CreateBookmarkUseCase.java
@@ -25,15 +25,14 @@ public class CreateBookmarkUseCase {
     private final BookmarkRepository bookmarkRepository;
 
     public String execute(String memberId, CreateBookmarkRequest request) {
-
-        Member member = memberRepository.getReferenceById(memberId);
-        String problemId = request.problemId();
-        Problem problem = problemRepository.findById(problemId)
-                .orElseThrow(() -> new ProblemBusinessException(ProblemErrorCode.PROBLEM_NOT_FOUND));
-
-        if (bookmarkRepository.existsByMemberIdAndProblemId(memberId, problemId)) {
+        if (bookmarkRepository.existsByMemberIdAndProblemId(memberId, request.problemId())) {
             throw new ProblemBusinessException(ProblemErrorCode.BOOKMARK_ALREADY_EXISTS);
         }
+
+        Member member = memberRepository.getReferenceById(memberId);
+        Problem problem = problemRepository.findById(request.problemId())
+                .orElseThrow(() -> new ProblemBusinessException(ProblemErrorCode.PROBLEM_NOT_FOUND));
+
 
         Bookmark bookmark = Bookmark.of(member, problem);
 

--- a/jabiseo-api/src/main/java/com/jabiseo/problem/usecase/DeleteBookmarkUseCase.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/problem/usecase/DeleteBookmarkUseCase.java
@@ -1,12 +1,25 @@
 package com.jabiseo.problem.usecase;
 
+import com.jabiseo.problem.domain.Bookmark;
+import com.jabiseo.problem.domain.BookmarkRepository;
 import com.jabiseo.problem.dto.DeleteBookmarkRequest;
+import com.jabiseo.problem.exception.ProblemBusinessException;
+import com.jabiseo.problem.exception.ProblemErrorCode;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional
+@RequiredArgsConstructor
 public class DeleteBookmarkUseCase {
 
-    public void execute(DeleteBookmarkRequest request) {
-        return;
+    private final BookmarkRepository bookmarkRepository;
+
+    public void execute(String memberId, DeleteBookmarkRequest request) {
+        Bookmark bookmark = bookmarkRepository.findByMemberIdAndProblemId(memberId, request.problemId())
+                .orElseThrow(() -> new ProblemBusinessException(ProblemErrorCode.BOOKMARK_NOT_FOUND));
+
+        bookmarkRepository.delete(bookmark);
     }
 }

--- a/jabiseo-api/src/main/java/com/jabiseo/problem/usecase/FindProblemsUseCase.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/problem/usecase/FindProblemsUseCase.java
@@ -6,6 +6,7 @@ import com.jabiseo.certificate.dto.ExamResponse;
 import com.jabiseo.certificate.dto.SubjectResponse;
 import com.jabiseo.certificate.exception.CertificateBusinessException;
 import com.jabiseo.certificate.exception.CertificateErrorCode;
+import com.jabiseo.problem.domain.Problem;
 import com.jabiseo.problem.domain.ProblemRepository;
 import com.jabiseo.problem.dto.ChoiceResponse;
 import com.jabiseo.problem.dto.FindProblemsRequest;
@@ -43,7 +44,7 @@ public class FindProblemsUseCase {
         validateProblemCount(count);
 
 
-        return subjectIds.stream()
+        List<Problem> problems = subjectIds.stream()
                 .map(subjectId -> {
                     if (examId.isPresent()) {
                         return problemRepository.findRandomByExamIdAndSubjectId(examId.get(), subjectId, count);
@@ -51,6 +52,9 @@ public class FindProblemsUseCase {
                     return problemRepository.findRandomBySubjectId(subjectId, count);
                 })
                 .flatMap(List::stream)
+                .toList();
+
+        return problems.stream()
                 .map(FindProblemsResponse::from)
                 .toList();
     }

--- a/jabiseo-api/src/test/java/com/jabiseo/fixture/ProblemFixture.java
+++ b/jabiseo-api/src/test/java/com/jabiseo/fixture/ProblemFixture.java
@@ -5,6 +5,10 @@ import com.jabiseo.certificate.domain.Exam;
 import com.jabiseo.certificate.domain.Subject;
 import com.jabiseo.problem.domain.Problem;
 
+import static com.jabiseo.fixture.CertificateFixture.createCertificate;
+import static com.jabiseo.fixture.ExamFixture.createExam;
+import static com.jabiseo.fixture.SubjectFixture.createSubject;
+
 public class ProblemFixture {
     public static Problem createProblem(String id, Certificate certificate, Exam exam, Subject subject) {
         return Problem.of(
@@ -21,6 +25,25 @@ public class ProblemFixture {
                 certificate,
                 exam,
                 subject
+        );
+    }
+
+    public static Problem createProblem(String id) {
+        Certificate certificate = createCertificate("1234");
+        return Problem.of(
+                id,
+                "problem description",
+                "choice1",
+                "choice2",
+                "choice3",
+                "choice4",
+                "choice5",
+                1,
+                "problem theory",
+                "problem solution",
+                certificate,
+                createExam("5432", certificate),
+                createSubject("9876", certificate)
         );
     }
 }

--- a/jabiseo-api/src/test/java/com/jabiseo/problem/usecase/CreateBookmarkUseCaseTest.java
+++ b/jabiseo-api/src/test/java/com/jabiseo/problem/usecase/CreateBookmarkUseCaseTest.java
@@ -1,0 +1,70 @@
+package com.jabiseo.problem.usecase;
+
+import com.jabiseo.member.domain.Member;
+import com.jabiseo.member.domain.MemberRepository;
+import com.jabiseo.problem.domain.Bookmark;
+import com.jabiseo.problem.domain.BookmarkRepository;
+import com.jabiseo.problem.domain.Problem;
+import com.jabiseo.problem.domain.ProblemRepository;
+import com.jabiseo.problem.dto.CreateBookmarkRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static com.jabiseo.fixture.MemberFixture.createMember;
+import static com.jabiseo.fixture.ProblemFixture.createProblem;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@DisplayName("북마크 생성 테스트")
+@ExtendWith(MockitoExtension.class)
+class CreateBookmarkUseCaseTest {
+
+    @InjectMocks
+    CreateBookmarkUseCase sut;
+
+    @Mock
+    MemberRepository memberRepository;
+
+    @Mock
+    ProblemRepository problemRepository;
+
+    @Mock
+    BookmarkRepository bookmarkRepository;
+
+    @Test
+    @DisplayName("북마크 생성 테스트 성공 케이스")        
+    void givenMemberIdAndProblemId_whenCreatingBookmark_thenCreateBookmark() throws Exception {
+        //given
+        String memberId = "1";
+        String problemId = "2";
+        Member member = createMember(memberId);
+        Problem problem = createProblem(problemId);
+        given(memberRepository.getReferenceById(memberId)).willReturn(member);
+        given(problemRepository.findById(problemId)).willReturn(Optional.of(problem));
+        given(bookmarkRepository.existsByMemberIdAndProblemId(memberId, problemId)).willReturn(false);
+        given(bookmarkRepository.save(any())).willReturn(Bookmark.of(member, problem));
+
+        
+        //when
+        sut.execute(memberId, new CreateBookmarkRequest(problemId));
+        
+        //then
+        ArgumentCaptor<Bookmark> bookmarkCaptor = ArgumentCaptor.forClass(Bookmark.class);
+        verify(bookmarkRepository).save(bookmarkCaptor.capture());
+        Bookmark savedBookmark = bookmarkCaptor.getValue();
+
+        assertThat(savedBookmark).isNotNull();
+        assertThat(savedBookmark.getMember().getId()).isEqualTo(memberId);
+        assertThat(savedBookmark.getProblem().getId()).isEqualTo(problemId);
+    }
+
+}

--- a/jabiseo-api/src/test/java/com/jabiseo/problem/usecase/DeleteBookmarkUseCaseTest.java
+++ b/jabiseo-api/src/test/java/com/jabiseo/problem/usecase/DeleteBookmarkUseCaseTest.java
@@ -1,0 +1,72 @@
+package com.jabiseo.problem.usecase;
+
+import com.jabiseo.member.domain.Member;
+import com.jabiseo.problem.domain.Bookmark;
+import com.jabiseo.problem.domain.BookmarkRepository;
+import com.jabiseo.problem.domain.Problem;
+import com.jabiseo.problem.dto.DeleteBookmarkRequest;
+import com.jabiseo.problem.exception.ProblemBusinessException;
+import com.jabiseo.problem.exception.ProblemErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static com.jabiseo.fixture.MemberFixture.createMember;
+import static com.jabiseo.fixture.ProblemFixture.createProblem;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@DisplayName("북마크 삭제 테스트")
+@ExtendWith(MockitoExtension.class)
+class DeleteBookmarkUseCaseTest {
+
+    @InjectMocks
+    DeleteBookmarkUseCase sut;
+
+    @Mock
+    BookmarkRepository bookmarkRepository;
+
+    @Test
+    @DisplayName("북마크 삭제 테스트 성공 케이스")
+    void givenMemberIdAndProblemId_whenDeletingBookmark_thenDeleteBookmark() {
+        //given
+        String memberId = "1";
+        String problemId = "2";
+        Member member = createMember(memberId);
+        Problem problem = createProblem(problemId);
+        Bookmark bookmark = Bookmark.of(member, problem);
+        given(bookmarkRepository.findByMemberIdAndProblemId(memberId, problemId)).willReturn(Optional.of(bookmark));
+
+        //when
+        sut.execute(memberId, new DeleteBookmarkRequest(problemId));
+
+        //then
+        ArgumentCaptor<Bookmark> bookmarkCaptor = ArgumentCaptor.forClass(Bookmark.class);
+        verify(bookmarkRepository).delete(bookmarkCaptor.capture());
+        Bookmark deletedBookmark = bookmarkCaptor.getValue();
+        assertThat(deletedBookmark).isEqualTo(bookmark);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 북마크를 삭제하는 경우 테스트")
+    void givenNonExistBookmarkWithMemberIdAndProblemId_whenDeletingBookmark_thenReturnError() {
+        //given
+        String memberId = "1";
+        String problemId = "2";
+        given(bookmarkRepository.findByMemberIdAndProblemId(memberId, problemId)).willReturn(Optional.empty());
+
+        //when & then
+        assertThatThrownBy(() -> sut.execute(memberId, new DeleteBookmarkRequest(problemId)))
+                .isInstanceOf(ProblemBusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ProblemErrorCode.BOOKMARK_NOT_FOUND);
+    }
+
+}

--- a/jabiseo-domain/src/main/java/com/jabiseo/member/domain/Member.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/member/domain/Member.java
@@ -1,6 +1,7 @@
 package com.jabiseo.member.domain;
 
 import com.jabiseo.certificate.domain.Certificate;
+import com.jabiseo.problem.domain.Bookmark;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -12,6 +13,8 @@ import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -51,6 +54,9 @@ public class Member {
     @JoinColumn(name = "certificate_state_id", foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
     private Certificate certificateState;
 
+    @OneToMany(mappedBy = "member")
+    private List<Bookmark> bookmarks = new ArrayList<>();
+
     private Member(String id, String email, String nickname, String oauthId, String oauthServer, String profileImage) {
         this.id = id;
         this.email = email;
@@ -70,4 +76,7 @@ public class Member {
         return this;
     }
 
+    public void addBookmark(Bookmark bookmark) {
+        bookmarks.add(bookmark);
+    }
 }

--- a/jabiseo-domain/src/main/java/com/jabiseo/problem/domain/Bookmark.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/problem/domain/Bookmark.java
@@ -1,0 +1,48 @@
+package com.jabiseo.problem.domain;
+
+import com.jabiseo.member.domain.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Bookmark {
+
+    @Id
+    @Column(name = "bookmark_id")
+    private String id;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "problem_id", foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
+    private Problem problem;
+
+    private Bookmark(String id, Member member, Problem problem) {
+        this.id = id;
+        this.member = member;
+        this.problem = problem;
+    }
+
+    public static Bookmark of(Member member, Problem problem) {
+        String id = UUID.randomUUID().toString(); //TODO: PK 생성 전략 변경 필요
+        Bookmark bookmark = new Bookmark(id, member, problem);
+        member.addBookmark(bookmark);
+        problem.addBookmark(bookmark);
+        return bookmark;
+    }
+
+}

--- a/jabiseo-domain/src/main/java/com/jabiseo/problem/domain/BookmarkRepository.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/problem/domain/BookmarkRepository.java
@@ -1,0 +1,9 @@
+package com.jabiseo.problem.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BookmarkRepository extends JpaRepository<Bookmark, String> {
+
+    boolean existsByMemberIdAndProblemId(String memberId, String problemId);
+
+}

--- a/jabiseo-domain/src/main/java/com/jabiseo/problem/domain/BookmarkRepository.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/problem/domain/BookmarkRepository.java
@@ -2,8 +2,12 @@ package com.jabiseo.problem.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface BookmarkRepository extends JpaRepository<Bookmark, String> {
 
     boolean existsByMemberIdAndProblemId(String memberId, String problemId);
+
+    Optional<Bookmark> findByMemberIdAndProblemId(String memberId, String problemId);
 
 }

--- a/jabiseo-domain/src/main/java/com/jabiseo/problem/domain/Problem.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/problem/domain/Problem.java
@@ -49,6 +49,9 @@ public class Problem {
     @JoinColumn(name = "subject_id", foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
     private Subject subject;
 
+    @OneToMany(mappedBy = "problem")
+    private List<Bookmark> bookmarks;
+
     public List<String> getChoices() {
         return Stream.of(choice1, choice2, choice3, choice4, choice5)
                 .filter((choice) -> choice != null && !choice.isBlank())
@@ -78,5 +81,9 @@ public class Problem {
                              Certificate certificate, Exam exam, Subject subject) {
         return new Problem(id, description, choice1, choice2, choice3, choice4, choice5,
                 answerNumber, theory, solution, certificate, exam, subject);
+    }
+
+    public void addBookmark(Bookmark bookmark) {
+        bookmarks.add(bookmark);
     }
 }

--- a/jabiseo-domain/src/main/java/com/jabiseo/problem/domain/Problem.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/problem/domain/Problem.java
@@ -7,6 +7,7 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -50,7 +51,7 @@ public class Problem {
     private Subject subject;
 
     @OneToMany(mappedBy = "problem")
-    private List<Bookmark> bookmarks;
+    private List<Bookmark> bookmarks = new ArrayList<>();
 
     public List<String> getChoices() {
         return Stream.of(choice1, choice2, choice3, choice4, choice5)

--- a/jabiseo-domain/src/main/java/com/jabiseo/problem/exception/ProblemErrorCode.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/problem/exception/ProblemErrorCode.java
@@ -6,8 +6,10 @@ import lombok.Getter;
 @Getter
 public enum ProblemErrorCode implements ErrorCode {
 
-    PROBLEM_NOT_FOUND("문제를 찾을 수 없습니다.", "PRO_001", ErrorCode.NOT_FOUND),
-    INVALID_PROBLEM_COUNT("문제의 개수가 올바르지 않습니다.", "PRO_002", ErrorCode.BAD_REQUEST);
+    PROBLEM_NOT_FOUND("문제를 찾을 수 없습니다.", "PRB_001", ErrorCode.NOT_FOUND),
+    INVALID_PROBLEM_COUNT("문제의 개수가 올바르지 않습니다.", "PRB_002", ErrorCode.BAD_REQUEST),
+    BOOKMARK_ALREADY_EXISTS("이미 북마크한 문제입니다.", "PRB_003", ErrorCode.BAD_REQUEST)
+    ;
 
 
     private final String message;

--- a/jabiseo-domain/src/main/java/com/jabiseo/problem/exception/ProblemErrorCode.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/problem/exception/ProblemErrorCode.java
@@ -8,7 +8,8 @@ public enum ProblemErrorCode implements ErrorCode {
 
     PROBLEM_NOT_FOUND("문제를 찾을 수 없습니다.", "PRB_001", ErrorCode.NOT_FOUND),
     INVALID_PROBLEM_COUNT("문제의 개수가 올바르지 않습니다.", "PRB_002", ErrorCode.BAD_REQUEST),
-    BOOKMARK_ALREADY_EXISTS("이미 북마크한 문제입니다.", "PRB_003", ErrorCode.BAD_REQUEST)
+    BOOKMARK_ALREADY_EXISTS("이미 북마크한 문제입니다.", "PRB_003", ErrorCode.BAD_REQUEST),
+    BOOKMARK_NOT_FOUND("북마크 정보를 찾을 수 없습니다.", "PRB_004", ErrorCode.NOT_FOUND)
     ;
 
 


### PR DESCRIPTION
## PR 변경된 내용
- Bookmark 생성/삭제 API 및 UseCase 단위 테스트 구현

## 추가 내용
### 로그인 과정에서 이미 데이터베이스에 있는 것이 확인된 Member의 경우 findById() 가 아니라 getReferencedById() 로 호출
- https://seungjjun.tistory.com/112
- "반드시 있어야 하는 데이터를 찾아야 할 때는 getreferenceById()를 사용하고, 있을 수도 있고 없을 수도 있는 데이터를 찾으려고 할 때는 findById()를 사용하는 것 같다."

## 참조

Jira Issue: SWM-36
