### PR TITLE
Feat(*): Member의 id를 Security에서 가져오도록 변경

### DIFF
--- a/jabiseo-api/src/main/java/com/jabiseo/member/application/usecase/UpdateMyCertificateStateUseCase.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/member/application/usecase/UpdateMyCertificateStateUseCase.java
@@ -2,7 +2,6 @@ package com.jabiseo.member.application.usecase;
 
 import com.jabiseo.certificate.domain.Certificate;
 import com.jabiseo.certificate.domain.CertificateRepository;
-import com.jabiseo.certificate.exception.CertificateBusinessException;
 import com.jabiseo.certificate.exception.CertificateErrorCode;
 import com.jabiseo.member.domain.Member;
 import com.jabiseo.member.domain.MemberRepository;
@@ -25,7 +24,7 @@ public class UpdateMyCertificateStateUseCase {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberBusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
         Certificate certificate = certificateRepository.findById(request.certificateId())
-                .orElseThrow(() -> new MemberBusinessException(MemberErrorCode.CURRENT_CERTIFICATE_NOT_EXIST));
+                .orElseThrow(() -> new MemberBusinessException(CertificateErrorCode.CERTIFICATE_NOT_FOUND));
         member.updateCertificateState(certificate);
     }
 }

--- a/jabiseo-api/src/main/java/com/jabiseo/member/controller/MemberController.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/member/controller/MemberController.java
@@ -24,24 +24,27 @@ public class MemberController {
     private final UpdateMyCertificateStateUseCase updateMyCertificateStateUseCase;
 
     @GetMapping
-    public ResponseEntity<FindMyInfoResponse> findMyInfo(@AuthenticatedMember AuthMember member) {
+    public ResponseEntity<FindMyInfoResponse> findMyInfo(
+            @AuthenticatedMember AuthMember member
+    ) {
         FindMyInfoResponse result = findMyInfoUseCase.execute(member.getMemberId());
         return ResponseEntity.ok(result);
     }
 
     @GetMapping("/certificates")
-    public ResponseEntity<FindMyCertificateStateResponse> findMyCertificateStatus() {
-        String memberId = "1"; // TODO: 로그인 기능 구현 후 JWT에서 memberId 가져오기
-        FindMyCertificateStateResponse result = findMyCertificateStateUseCase.execute(memberId);
+    public ResponseEntity<FindMyCertificateStateResponse> findMyCertificateStatus(
+            @AuthenticatedMember AuthMember member
+    ) {
+        FindMyCertificateStateResponse result = findMyCertificateStateUseCase.execute(member.getMemberId());
         return ResponseEntity.ok(result);
     }
 
     @PatchMapping("/certificates")
     public ResponseEntity<Void> updateMyCertificateStatus(
-            @RequestBody UpdateMyCertificateStateRequest request
+            @RequestBody UpdateMyCertificateStateRequest request,
+            @AuthenticatedMember AuthMember member
     ) {
-        String memberId = "1"; // TODO: 로그인 기능 구현 후 JWT에서 memberId 가져오기
-        updateMyCertificateStateUseCase.execute(memberId, request);
+        updateMyCertificateStateUseCase.execute(member.getMemberId(), request);
         return ResponseEntity.ok().build();
     }
 

--- a/jabiseo-api/src/main/java/com/jabiseo/problem/application/usecase/FindProblemsUseCase.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/problem/application/usecase/FindProblemsUseCase.java
@@ -30,6 +30,7 @@ public class FindProblemsUseCase {
 
     private final ProblemRepository problemRepository;
 
+    // TODO: 문제에 북마크 되어 있는지 표시해야 함
     public List<FindProblemsResponse> execute(String certificateId, List<String> subjectIds, Optional<String> examId, int count) {
         Certificate certificate = certificateRepository.findById(certificateId)
                 .orElseThrow(() -> new CertificateBusinessException(CertificateErrorCode.CERTIFICATE_NOT_FOUND));
@@ -54,6 +55,7 @@ public class FindProblemsUseCase {
                 .toList();
     }
 
+    // TODO: 문제에 북마크 되어 있는지 표시해야 함
     public List<FindProblemsResponse> execute(FindProblemsRequest request) {
         return request.problemIds().stream()
                 .map(problemId -> problemRepository.findById(problemId)

--- a/jabiseo-api/src/main/java/com/jabiseo/problem/controller/BookmarkController.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/problem/controller/BookmarkController.java
@@ -27,8 +27,7 @@ public class BookmarkController {
             @RequestBody CreateBookmarkRequest request,
             @AuthenticatedMember AuthMember member
     ) {
-        String memberId = "1"; // TODO : 로그인 기능 구현 후 로그인한 사용자의 ID로 변경
-        String bookmarkId = createBookmarkUseCase.execute(memberId, request);
+        String bookmarkId = createBookmarkUseCase.execute(member.getMemberId(), request);
 
         URI location = ServletUriComponentsBuilder
                 .fromCurrentRequest()
@@ -44,8 +43,7 @@ public class BookmarkController {
             @RequestBody DeleteBookmarkRequest request,
             @AuthenticatedMember AuthMember member
     ) {
-        String memberId = "1"; // TODO : 로그인 기능 구현 후 로그인한 사용자의 ID로 변경
-        deleteBookmarkUseCase.execute(memberId, request);
+        deleteBookmarkUseCase.execute(member.getMemberId(), request);
         return ResponseEntity.noContent().build();
     }
 }

--- a/jabiseo-api/src/main/java/com/jabiseo/problem/controller/BookmarkController.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/problem/controller/BookmarkController.java
@@ -1,9 +1,11 @@
 package com.jabiseo.problem.controller;
 
-import com.jabiseo.problem.dto.CreateBookmarkRequest;
-import com.jabiseo.problem.dto.DeleteBookmarkRequest;
+import com.jabiseo.config.auth.AuthMember;
+import com.jabiseo.config.auth.AuthenticatedMember;
 import com.jabiseo.problem.application.usecase.CreateBookmarkUseCase;
 import com.jabiseo.problem.application.usecase.DeleteBookmarkUseCase;
+import com.jabiseo.problem.dto.CreateBookmarkRequest;
+import com.jabiseo.problem.dto.DeleteBookmarkRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -22,7 +24,8 @@ public class BookmarkController {
 
     @PostMapping
     public ResponseEntity<Void> createBookmark(
-            @RequestBody CreateBookmarkRequest request
+            @RequestBody CreateBookmarkRequest request,
+            @AuthenticatedMember AuthMember member
     ) {
         String memberId = "1"; // TODO : 로그인 기능 구현 후 로그인한 사용자의 ID로 변경
         String bookmarkId = createBookmarkUseCase.execute(memberId, request);
@@ -38,7 +41,8 @@ public class BookmarkController {
 
     @DeleteMapping
     public ResponseEntity<Void> deleteBookmark(
-            @RequestBody DeleteBookmarkRequest request
+            @RequestBody DeleteBookmarkRequest request,
+            @AuthenticatedMember AuthMember member
     ) {
         String memberId = "1"; // TODO : 로그인 기능 구현 후 로그인한 사용자의 ID로 변경
         deleteBookmarkUseCase.execute(memberId, request);

--- a/jabiseo-api/src/main/java/com/jabiseo/problem/controller/ProblemController.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/problem/controller/ProblemController.java
@@ -1,5 +1,7 @@
 package com.jabiseo.problem.controller;
 
+import com.jabiseo.config.auth.AuthMember;
+import com.jabiseo.config.auth.AuthenticatedMember;
 import com.jabiseo.problem.dto.CreateReportRequest;
 import com.jabiseo.problem.dto.FindBookmarkedProblemsResponse;
 import com.jabiseo.problem.dto.FindProblemsRequest;
@@ -31,6 +33,7 @@ public class ProblemController {
 
     @GetMapping("/set")
     public ResponseEntity<List<FindProblemsResponse>> findProblems(
+            @AuthenticatedMember AuthMember member,
             // TODO: DTO 기반으로 변경
             @RequestParam(name = "certificate-id") String certificateId,
             @RequestParam(name = "subject-id") List<String> subjectIds,
@@ -47,6 +50,7 @@ public class ProblemController {
 
     @PostMapping("/set/query")
     public ResponseEntity<List<FindProblemsResponse>> findProblems(
+            @AuthenticatedMember AuthMember member,
             @RequestBody FindProblemsRequest request
     ) {
         List<FindProblemsResponse> result = findProblemsUseCase.execute(request);
@@ -70,13 +74,13 @@ public class ProblemController {
 
     @GetMapping("/bookmarked")
     public ResponseEntity<List<FindBookmarkedProblemsResponse>> findBookmarkedProblems(
+            @AuthenticatedMember AuthMember member,
             // TODO: DTO 기반으로 변경
             @RequestParam(name = "exam-id") Optional<String> examId,
             @RequestParam(name = "subject-id") List<String> subjectIds,
             int page
     ) {
-        String memberId = "1"; // TODO: 로그인 기능 구현 후 로그인한 사용자의 ID로 변경
-        List<FindBookmarkedProblemsResponse> result = findBookmarkedProblemsUseCase.execute(memberId, examId, subjectIds, page);
+        List<FindBookmarkedProblemsResponse> result = findBookmarkedProblemsUseCase.execute(member.getMemberId(), examId, subjectIds, page);
         return ResponseEntity.ok(result);
     }
 }

--- a/jabiseo-api/src/test/java/com/jabiseo/member/application/usecase/UpdateMyCertificateStateUseCaseTest.java
+++ b/jabiseo-api/src/test/java/com/jabiseo/member/application/usecase/UpdateMyCertificateStateUseCaseTest.java
@@ -2,6 +2,7 @@ package com.jabiseo.member.application.usecase;
 
 import com.jabiseo.certificate.domain.Certificate;
 import com.jabiseo.certificate.domain.CertificateRepository;
+import com.jabiseo.certificate.exception.CertificateErrorCode;
 import com.jabiseo.member.domain.Member;
 import com.jabiseo.member.domain.MemberRepository;
 import com.jabiseo.member.dto.UpdateMyCertificateStateRequest;
@@ -71,7 +72,7 @@ class UpdateMyCertificateStateUseCaseTest {
     }
 
     @Test
-    @DisplayName("존재하지 않는 현재 자격증 변경을 시도하면 예외처리한다.")
+    @DisplayName("존재하지 않는 자격증으로 현재 자격증 변경을 시도하면 예외처리한다.")
     void givenMemberIdAndNonExistedCertificateId_whenUpdatingCertificateState_thenReturnError() {
         //given
         String memberId = "1";
@@ -84,7 +85,7 @@ class UpdateMyCertificateStateUseCaseTest {
         UpdateMyCertificateStateRequest request = new UpdateMyCertificateStateRequest(nonExistedCertificateId);
         assertThatThrownBy(() -> sut.execute(memberId, request))
                 .isInstanceOf(MemberBusinessException.class)
-                .hasFieldOrPropertyWithValue("errorCode", MemberErrorCode.CURRENT_CERTIFICATE_NOT_EXIST);
+                .hasFieldOrPropertyWithValue("errorCode", CertificateErrorCode.CERTIFICATE_NOT_FOUND);
     }
 
 }

--- a/jabiseo-domain/src/test/java/com/jabiseo/member/domain/MemberTest.java
+++ b/jabiseo-domain/src/test/java/com/jabiseo/member/domain/MemberTest.java
@@ -1,0 +1,47 @@
+package com.jabiseo.member.domain;
+
+import com.jabiseo.certificate.domain.Certificate;
+import com.jabiseo.member.exception.MemberBusinessException;
+import com.jabiseo.member.exception.MemberErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static fixture.CertificateFixture.createCertificate;
+import static fixture.MemberFixture.createMember;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("회원 도메인 테스트")
+class MemberTest {
+
+    @Test
+    @DisplayName("회원의 현재 자격증이 존재해서 현재 자격증 존재 검사에서 예외가 발생하지 않는다.")
+    void givenMember_whenValidateCurrentCertificate_thenDoesNotThrowException() {
+        //given
+        String memberId = "1";
+        String certificateId = "2";
+        Member member = createMember(memberId);
+        Certificate certificate = createCertificate(certificateId);
+        member.updateCertificateState(certificate);
+
+        //when & then
+        assertDoesNotThrow(member::validateCurrentCertificate);
+    }
+
+    @Test
+    @DisplayName("회원의 현재 자격증이 존재하지 않아 현재 자격증 존재 검사에서 예외가 발생한다.")
+    void givenMemberWithoutCurrentCertificate_whenValidateCurrentCertificate_thenThrowException() {
+        //given
+        String memberId = "1";
+        Member member = createMember(memberId);
+
+        //when & then
+        assertThatThrownBy(member::validateCurrentCertificate)
+                .isInstanceOf(MemberBusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", MemberErrorCode.CURRENT_CERTIFICATE_NOT_EXIST);
+    }
+
+}


### PR DESCRIPTION
## PR 변경된 내용
- Contoller에서 memberId = "1" 과 같은 식으로 하드코딩되어 있는 것을 SecurityContext에서 가져오도록 변경

## 추가 내용
- Member의 validate 테스트 코드 구현
- 에러 코드가 잘못 올라가 있었던 오류 수정

## 참조
Closes #30 
