### PR TITLE
Feat(*): Entity의 primary key type 변경

### DIFF
--- a/jabiseo-api/src/main/java/com/jabiseo/auth/dto/ReissueRequest.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/auth/dto/ReissueRequest.java
@@ -2,5 +2,8 @@ package com.jabiseo.auth.dto;
 
 import jakarta.validation.constraints.NotBlank;
 
-public record ReissueRequest(@NotBlank String refreshToken) {
+public record ReissueRequest(
+        @NotBlank
+        String refreshToken
+) {
 }

--- a/jabiseo-api/src/main/java/com/jabiseo/auth/dto/ReissueResponse.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/auth/dto/ReissueResponse.java
@@ -1,5 +1,6 @@
 package com.jabiseo.auth.dto;
 
-public record ReissueResponse(String accessToken) {
-
+public record ReissueResponse(
+        String accessToken
+) {
 }

--- a/jabiseo-api/src/main/java/com/jabiseo/certificate/application/usecase/FindCertificateDetailUseCase.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/certificate/application/usecase/FindCertificateDetailUseCase.java
@@ -16,8 +16,8 @@ public class FindCertificateDetailUseCase {
 
     private final CertificateRepository certificateRepository;
 
-    public FindCertificateDetailResponse execute(String id) {
-        Certificate certificate = certificateRepository.findById(id)
+    public FindCertificateDetailResponse execute(Long certificateId) {
+        Certificate certificate = certificateRepository.findById(certificateId)
                 .orElseThrow(() -> new CertificateBusinessException(CertificateErrorCode.CERTIFICATE_NOT_FOUND));
         return FindCertificateDetailResponse.from(certificate);
     }

--- a/jabiseo-api/src/main/java/com/jabiseo/certificate/controller/CertificateController.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/certificate/controller/CertificateController.java
@@ -30,7 +30,7 @@ public class CertificateController {
 
     @GetMapping("/{certificate-id}")
     public ResponseEntity<FindCertificateDetailResponse> findCertificate(
-            @PathVariable(name = "certificate-id") String certificateId
+            @PathVariable(name = "certificate-id") Long certificateId
     ) {
         FindCertificateDetailResponse result = findCertificateDetailUseCase.execute(certificateId);
         return ResponseEntity.ok(result);

--- a/jabiseo-api/src/main/java/com/jabiseo/certificate/dto/ExamResponse.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/certificate/dto/ExamResponse.java
@@ -3,7 +3,7 @@ package com.jabiseo.certificate.dto;
 import com.jabiseo.certificate.domain.Exam;
 
 public record ExamResponse(
-        String examId,
+        Long examId,
         String description
 ) {
     public static ExamResponse from(Exam exam) {

--- a/jabiseo-api/src/main/java/com/jabiseo/certificate/dto/FindCertificateDetailResponse.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/certificate/dto/FindCertificateDetailResponse.java
@@ -5,7 +5,7 @@ import com.jabiseo.certificate.domain.Certificate;
 import java.util.List;
 
 public record FindCertificateDetailResponse(
-        String certificateId,
+        Long certificateId,
         String name,
         List<ExamResponse> exams,
         List<SubjectResponse> subjects

--- a/jabiseo-api/src/main/java/com/jabiseo/certificate/dto/FindCertificateListResponse.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/certificate/dto/FindCertificateListResponse.java
@@ -4,7 +4,7 @@ package com.jabiseo.certificate.dto;
 import com.jabiseo.certificate.domain.Certificate;
 
 public record FindCertificateListResponse(
-        String certificateId,
+        Long certificateId,
         String name
 ) {
     public static FindCertificateListResponse from(Certificate certificate) {

--- a/jabiseo-api/src/main/java/com/jabiseo/certificate/dto/SubjectResponse.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/certificate/dto/SubjectResponse.java
@@ -1,11 +1,13 @@
 package com.jabiseo.certificate.dto;
 
+import com.jabiseo.certificate.domain.Subject;
+
 public record SubjectResponse(
-        String subjectId,
+        Long subjectId,
         int sequence,
         String name
 ) {
-    public static SubjectResponse from(com.jabiseo.certificate.domain.Subject subject) {
+    public static SubjectResponse from(Subject subject) {
         return new SubjectResponse(subject.getId(), subject.getSequence(), subject.getName());
     }
 }

--- a/jabiseo-api/src/main/java/com/jabiseo/member/dto/FindMyCurrentCertificateResponse.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/member/dto/FindMyCurrentCertificateResponse.java
@@ -5,7 +5,7 @@ import com.jabiseo.member.domain.Member;
 
 public record FindMyCurrentCertificateResponse(
         String memberId,
-        String certificateId
+        Long certificateId
 ) {
     public static FindMyCurrentCertificateResponse of(Member member, Certificate certificate) {
         return new FindMyCurrentCertificateResponse(member.getId(), certificate.getId());

--- a/jabiseo-api/src/main/java/com/jabiseo/member/dto/UpdateMyCurrentCertificateRequest.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/member/dto/UpdateMyCurrentCertificateRequest.java
@@ -1,6 +1,6 @@
 package com.jabiseo.member.dto;
 
 public record UpdateMyCurrentCertificateRequest(
-        String certificateId
+        Long certificateId
 ) {
 }

--- a/jabiseo-api/src/main/java/com/jabiseo/problem/application/usecase/FindBookmarkedProblemsUseCase.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/problem/application/usecase/FindBookmarkedProblemsUseCase.java
@@ -27,7 +27,7 @@ public class FindBookmarkedProblemsUseCase {
 
     private final ProblemRepository problemRepository;
 
-    public FindBookmarkedProblemsResponse execute(String memberId, Optional<String> examId, List<String> subjectIds, int page) {
+    public FindBookmarkedProblemsResponse execute(String memberId, Optional<Long> examId, List<Long> subjectIds, int page) {
 
         Pageable pageable = PageRequest.of(page, DEFAULT_PAGE_SIZE);
 

--- a/jabiseo-api/src/main/java/com/jabiseo/problem/application/usecase/FindProblemsUseCase.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/problem/application/usecase/FindProblemsUseCase.java
@@ -25,7 +25,7 @@ public class FindProblemsUseCase {
     private final ProblemRepository problemRepository;
 
     // TODO: 문제에 북마크 되어 있는지 표시해야 함
-    public FindProblemsResponse execute(String certificateId, List<String> subjectIds, Optional<String> examId, int count) {
+    public FindProblemsResponse execute(Long certificateId, List<Long> subjectIds, Optional<Long> examId, int count) {
         Certificate certificate = certificateRepository.findById(certificateId)
                 .orElseThrow(() -> new CertificateBusinessException(CertificateErrorCode.CERTIFICATE_NOT_FOUND));
 

--- a/jabiseo-api/src/main/java/com/jabiseo/problem/controller/ProblemController.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/problem/controller/ProblemController.java
@@ -35,9 +35,9 @@ public class ProblemController {
     public ResponseEntity<FindProblemsResponse> findProblems(
             @AuthenticatedMember AuthMember member,
             // TODO: Valid에 대한 테스트
-            @RequestParam(name = "certificate-id") String certificateId,
-            @RequestParam(name = "subject-id") List<String> subjectIds,
-            @RequestParam(name = "exam-id", required = false) Optional<String> examId,
+            @RequestParam(name = "certificate-id") Long certificateId,
+            @RequestParam(name = "subject-id") List<Long> subjectIds,
+            @RequestParam(name = "exam-id", required = false) Optional<Long> examId,
             @RequestParam
             @Min(value = 1, message = "과목 당 문제 수는 0보다 커야 합니다.")
             @Max(value = 20, message = "과목 당 문제 수는 20보다 작거나 같아야 합니다.")
@@ -76,8 +76,8 @@ public class ProblemController {
     public ResponseEntity<FindBookmarkedProblemsResponse> findBookmarkedProblems(
             @AuthenticatedMember AuthMember member,
             // TODO: DTO 기반으로 변경
-            @RequestParam(name = "exam-id") Optional<String> examId,
-            @RequestParam(name = "subject-id") List<String> subjectIds,
+            @RequestParam(name = "exam-id") Optional<Long> examId,
+            @RequestParam(name = "subject-id") List<Long> subjectIds,
             int page
     ) {
         FindBookmarkedProblemsResponse result = findBookmarkedProblemsUseCase.execute(member.getMemberId(), examId, subjectIds, page);

--- a/jabiseo-api/src/main/java/com/jabiseo/problem/dto/CertificateResponse.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/problem/dto/CertificateResponse.java
@@ -3,7 +3,7 @@ package com.jabiseo.problem.dto;
 import com.jabiseo.certificate.domain.Certificate;
 
 public record CertificateResponse(
-        String certificateId,
+        Long certificateId,
         String name
 ) {
     public static CertificateResponse from(Certificate certificate) {

--- a/jabiseo-api/src/main/java/com/jabiseo/problem/dto/CreateBookmarkRequest.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/problem/dto/CreateBookmarkRequest.java
@@ -1,6 +1,6 @@
 package com.jabiseo.problem.dto;
 
 public record CreateBookmarkRequest(
-        String problemId
+        Long problemId
 ) {
 }

--- a/jabiseo-api/src/main/java/com/jabiseo/problem/dto/DeleteBookmarkRequest.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/problem/dto/DeleteBookmarkRequest.java
@@ -1,6 +1,6 @@
 package com.jabiseo.problem.dto;
 
 public record DeleteBookmarkRequest(
-        String problemId
+        Long problemId
 ) {
 }

--- a/jabiseo-api/src/main/java/com/jabiseo/problem/dto/FindProblemsRequest.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/problem/dto/FindProblemsRequest.java
@@ -3,6 +3,6 @@ package com.jabiseo.problem.dto;
 import java.util.List;
 
 public record FindProblemsRequest(
-        List<String> problemIds
+        List<Long> problemIds
 ) {
 }

--- a/jabiseo-api/src/main/java/com/jabiseo/problem/dto/ProblemsDetailResponse.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/problem/dto/ProblemsDetailResponse.java
@@ -7,7 +7,7 @@ import com.jabiseo.problem.domain.Problem;
 import java.util.List;
 
 public record ProblemsDetailResponse(
-        String problemId,
+        Long problemId,
         ExamResponse examInfo,
         SubjectResponse subjectInfo,
         boolean isBookmark,

--- a/jabiseo-api/src/main/java/com/jabiseo/problem/dto/ProblemsResponse.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/problem/dto/ProblemsResponse.java
@@ -5,7 +5,7 @@ import com.jabiseo.certificate.dto.SubjectResponse;
 import com.jabiseo.problem.domain.Problem;
 
 public record ProblemsResponse(
-        String problemId,
+        Long problemId,
         ExamResponse examInfo,
         SubjectResponse subjectInfo,
         boolean isBookmark,

--- a/jabiseo-api/src/test/java/com/jabiseo/auth/application/usecase/ReissueUseCaseTest.java
+++ b/jabiseo-api/src/test/java/com/jabiseo/auth/application/usecase/ReissueUseCaseTest.java
@@ -9,7 +9,6 @@ import com.jabiseo.cache.RedisCacheRepository;
 import com.jabiseo.member.domain.Member;
 import com.jabiseo.member.domain.MemberRepository;
 import fixture.MemberFixture;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -22,7 +21,6 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)

--- a/jabiseo-api/src/test/java/com/jabiseo/certificate/application/usecase/FindCertificateDetailUseCaseTest.java
+++ b/jabiseo-api/src/test/java/com/jabiseo/certificate/application/usecase/FindCertificateDetailUseCaseTest.java
@@ -35,9 +35,9 @@ class FindCertificateDetailUseCaseTest {
     @DisplayName("자격증 정보 조회를 성공한다.")
     void givenCertificateId_whenFindingCertificate_thenFindCertificate() {
         //given
-        String certificateId = "1";
-        String examId = "2";
-        String subjectId = "3";
+        Long certificateId = 1L;
+        Long examId = 2L;
+        Long subjectId = 3L;
         Certificate certificate = createCertificate(certificateId);
         createExam(examId, certificate);
         createSubject(subjectId, certificate);
@@ -57,7 +57,7 @@ class FindCertificateDetailUseCaseTest {
     @DisplayName("존재하지 않는 자격증 정보를 조회하면 예외처리한다.")
     void givenNonExistedCertificateId_whenFindingCertificate_thenReturnException() {
         //given
-        String nonExistedCertificateId = "1";
+        Long nonExistedCertificateId = 1L;
         given(certificateRepository.findById(nonExistedCertificateId)).willReturn(Optional.empty());
 
         //when & then

--- a/jabiseo-api/src/test/java/com/jabiseo/certificate/application/usecase/FindCertificateListUseCaseTest.java
+++ b/jabiseo-api/src/test/java/com/jabiseo/certificate/application/usecase/FindCertificateListUseCaseTest.java
@@ -30,8 +30,8 @@ class FindCertificateListUseCaseTest {
     @DisplayName("자격증 목록 조회를 성공한다.")
     void givenCertificates_whenFindingCertificates_thenFindCertificates() {
         //given
-        String certificateId1 = "1";
-        String certificateId2 = "2";
+        Long certificateId1 = 1L;
+        Long certificateId2 = 2L;
         Certificate certificate1 = createCertificate(certificateId1);
         Certificate certificate2 = createCertificate(certificateId2);
         given(certificateRepository.findAll()).willReturn(List.of(certificate1, certificate2));

--- a/jabiseo-api/src/test/java/com/jabiseo/member/application/usecase/FindMyCurrentCertificateUseCaseTest.java
+++ b/jabiseo-api/src/test/java/com/jabiseo/member/application/usecase/FindMyCurrentCertificateUseCaseTest.java
@@ -36,7 +36,7 @@ class FindMyCurrentCertificateUseCaseTest {
     void givenMemberId_whenFindingCurrentCertificate_thenFindCertificateStatus() {
         //given
         String memberId = "1";
-        String certificateId = "2";
+        Long certificateId = 2L;
         Certificate certificate = createCertificate(certificateId);
         Member member = createMember(memberId);
         member.updateCurrentCertificate(certificate);

--- a/jabiseo-api/src/test/java/com/jabiseo/member/application/usecase/UpdateMyCurrentCertificateUseCaseTest.java
+++ b/jabiseo-api/src/test/java/com/jabiseo/member/application/usecase/UpdateMyCurrentCertificateUseCaseTest.java
@@ -41,7 +41,7 @@ class UpdateMyCurrentCertificateUseCaseTest {
     void givenMemberIdAndCertificateId_whenUpdatingCurrentCertificate_thenUpdateCurrentCertificate() {
         //given
         String memberId = "1";
-        String certificateId = "2";
+        Long certificateId = 2L;
         Member member = createMember(memberId);
         Certificate certificate = createCertificate(certificateId);
         given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
@@ -60,7 +60,7 @@ class UpdateMyCurrentCertificateUseCaseTest {
     void givenCertificateIdAndNonExistedMemberId_whenUpdatingCurrentCertificate_thenReturnError() {
         //given
         String nonExistedMemberId = "1";
-        String certificateId = "2";
+        Long certificateId = 2L;
         given(memberRepository.findById(nonExistedMemberId)).willReturn(Optional.empty());
 
         //when & then
@@ -76,7 +76,7 @@ class UpdateMyCurrentCertificateUseCaseTest {
     void givenMemberIdAndNonExistedCertificateId_whenUpdatingCurrentCertificate_thenReturnError() {
         //given
         String memberId = "1";
-        String nonExistedCertificateId = "2";
+        Long nonExistedCertificateId = 2L;
         Member member = createMember(memberId);
         given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
         given(certificateRepository.findById(nonExistedCertificateId)).willReturn(Optional.empty());

--- a/jabiseo-api/src/test/java/com/jabiseo/problem/application/usecase/CreateBookmarkUseCaseTest.java
+++ b/jabiseo-api/src/test/java/com/jabiseo/problem/application/usecase/CreateBookmarkUseCaseTest.java
@@ -48,7 +48,7 @@ class CreateBookmarkUseCaseTest {
     void givenMemberIdAndProblemId_whenCreatingBookmark_thenCreateBookmark() {
         //given
         String memberId = "1";
-        String problemId = "2";
+        Long problemId = 2L;
         Member member = createMember(memberId);
         Problem problem = createProblem(problemId);
         given(memberRepository.getReferenceById(memberId)).willReturn(member);
@@ -74,7 +74,7 @@ class CreateBookmarkUseCaseTest {
     void givenAlreadyExistedMemberIdAndProblemId_whenCreatingBookmark_thenReturnError() {
         //given
         String memberId = "1";
-        String problemId = "2";
+        Long problemId = 2L;
         given(bookmarkRepository.existsByMemberIdAndProblemId(memberId, problemId)).willReturn(true);
 
 
@@ -90,7 +90,7 @@ class CreateBookmarkUseCaseTest {
     void givenMemberIdAndNonExistedProblemId_whenCreatingBookmark_thenReturnError() {
         //given
         String memberId = "1";
-        String problemId = "2";
+        Long problemId = 2L;
         given(bookmarkRepository.existsByMemberIdAndProblemId(memberId, problemId)).willReturn(false);
         given(problemRepository.findById(problemId)).willReturn(Optional.empty());
 

--- a/jabiseo-api/src/test/java/com/jabiseo/problem/application/usecase/DeleteBookmarkUseCaseTest.java
+++ b/jabiseo-api/src/test/java/com/jabiseo/problem/application/usecase/DeleteBookmarkUseCaseTest.java
@@ -39,7 +39,7 @@ class DeleteBookmarkUseCaseTest {
     void givenMemberIdAndProblemId_whenDeletingBookmark_thenDeleteBookmark() {
         //given
         String memberId = "1";
-        String problemId = "2";
+        Long problemId = 2L;
         Member member = createMember(memberId);
         Problem problem = createProblem(problemId);
         Bookmark bookmark = Bookmark.of(member, problem);
@@ -60,7 +60,7 @@ class DeleteBookmarkUseCaseTest {
     void givenNonExistBookmarkWithMemberIdAndProblemId_whenDeletingBookmark_thenReturnError() {
         //given
         String memberId = "1";
-        String problemId = "2";
+        Long problemId = 2L;
         given(bookmarkRepository.findByMemberIdAndProblemId(memberId, problemId)).willReturn(Optional.empty());
 
         //when & then

--- a/jabiseo-api/src/test/java/com/jabiseo/problem/application/usecase/FindBookmarkedProblemsUseCaseTest.java
+++ b/jabiseo-api/src/test/java/com/jabiseo/problem/application/usecase/FindBookmarkedProblemsUseCaseTest.java
@@ -49,11 +49,11 @@ class FindBookmarkedProblemsUseCaseTest {
     void givenProblemConditionsContainsExamId_whenFindingBookmarkedProblems_thenFindBookmarkedProblems() {
         //given
         String memberId = "1";
-        String certificateId = "2";
-        String examId = "3";
-        String subjectId = "4";
-        String problemId1 = "5";
-        String problemId2 = "6";
+        Long certificateId = 2L;
+        Long examId = 3L;
+        Long subjectId = 4L;
+        Long problemId1 = 5L;
+        Long problemId2 = 6L;
 
         Member member = createMember(memberId);
         Certificate certificate = createCertificate(certificateId);
@@ -82,10 +82,10 @@ class FindBookmarkedProblemsUseCaseTest {
     void givenProblemConditionsExceptExamId_whenFindingBookmarkedProblems_thenFindBookmarkedProblems() {
         //given
         String memberId = "1";
-        String certificateId = "2";
-        String subjectId = "4";
-        String problemId1 = "5";
-        String problemId2 = "6";
+        Long certificateId = 2L;
+        Long subjectId = 4L;
+        Long problemId1 = 5L;
+        Long problemId2 = 6L;
 
         Member member = createMember(memberId);
         Certificate certificate = createCertificate(certificateId);
@@ -113,8 +113,8 @@ class FindBookmarkedProblemsUseCaseTest {
     void givenMemberWithNoCurrentCertificate_whenFindingBookmarkedProblems_thenReturnError() {
         //given
         String memberId = "1";
-        String examId = "3";
-        String subjectId = "4";
+        Long examId = 3L;
+        Long subjectId = 4L;
 
         Member member = createMember(memberId);
         given(memberRepository.getReferenceById(memberId)).willReturn(member);

--- a/jabiseo-api/src/test/java/com/jabiseo/problem/application/usecase/FindProblemsByIdUseCaseTest.java
+++ b/jabiseo-api/src/test/java/com/jabiseo/problem/application/usecase/FindProblemsByIdUseCaseTest.java
@@ -44,28 +44,30 @@ class FindProblemsByIdUseCaseTest {
     void givenProblemIds_whenFindingProblems_thenFindProblems() {
         //given
         String memberId = "1";
-        String certificateId = "2";
-        String[] problemIds = {"3", "4", "5"};
+        Long certificateId = 2L;
+        List<Long> problemIds = List.of(3L, 4L, 5L);
         Member member = createMember(memberId);
         Certificate certificate = createCertificate(certificateId);
         member.updateCurrentCertificate(certificate);
-        Problem problem1 = createProblem(problemIds[0], certificate);
-        Problem problem2 = createProblem(problemIds[1], certificate);
-        Problem problem3 = createProblem(problemIds[2], certificate);
-        FindProblemsRequest request = new FindProblemsRequest(List.of(problemIds));
+        List<Problem> problems = List.of(
+                createProblem(problemIds.get(0), certificate),
+                createProblem(problemIds.get(1), certificate),
+                createProblem(problemIds.get(2), certificate)
+        );
+        FindProblemsRequest request = new FindProblemsRequest(problemIds);
         given(memberRepository.getReferenceById(memberId)).willReturn(member);
-        given(problemRepository.findById(problemIds[0])).willReturn(Optional.of(problem1));
-        given(problemRepository.findById(problemIds[1])).willReturn(Optional.of(problem2));
-        given(problemRepository.findById(problemIds[2])).willReturn(Optional.of(problem3));
+        given(problemRepository.findById(problemIds.get(0))).willReturn(Optional.of(problems.get(0)));
+        given(problemRepository.findById(problemIds.get(1))).willReturn(Optional.of(problems.get(1)));
+        given(problemRepository.findById(problemIds.get(2))).willReturn(Optional.of(problems.get(2)));
 
         //when
         FindProblemsResponse result = sut.execute(member.getId(), request);
 
         //then
         assertThat(result.certificateInfo().certificateId()).isEqualTo(certificateId);
-        assertThat(result.problems().get(0).problemId()).isEqualTo(problemIds[0]);
-        assertThat(result.problems().get(1).problemId()).isEqualTo(problemIds[1]);
-        assertThat(result.problems().get(2).problemId()).isEqualTo(problemIds[2]);
+        assertThat(result.problems().get(0).problemId()).isEqualTo(problemIds.get(0));
+        assertThat(result.problems().get(1).problemId()).isEqualTo(problemIds.get(1));
+        assertThat(result.problems().get(2).problemId()).isEqualTo(problemIds.get(2));
     }
 
     @Test
@@ -73,17 +75,15 @@ class FindProblemsByIdUseCaseTest {
     void givenNonExistedProblemIds_whenFindingProblems_thenReturnError() {
         //given
         String memberId = "1";
-        String certificateId = "2";
-        String[] problemIds = {"3", "4", "5"};
+        Long certificateId = 2L;
+        List<Long> problemIds = List.of(3L, 4L, 5L);
         Member member = createMember(memberId);
         Certificate certificate = createCertificate(certificateId);
         member.updateCurrentCertificate(certificate);
-        createProblem(problemIds[0], certificate);
-        createProblem(problemIds[1], certificate);
-        createProblem(problemIds[2], certificate);
-        FindProblemsRequest request = new FindProblemsRequest(List.of(problemIds));
+        problemIds.forEach(problemId -> createProblem(problemId, certificate));
+        FindProblemsRequest request = new FindProblemsRequest(problemIds);
         given(memberRepository.getReferenceById(memberId)).willReturn(member);
-        given(problemRepository.findById(problemIds[0])).willReturn(Optional.empty());
+        given(problemRepository.findById(problemIds.get(0))).willReturn(Optional.empty());
 
         //when & then
         assertThatThrownBy(() -> sut.execute(member.getId(), request))

--- a/jabiseo-domain/build.gradle
+++ b/jabiseo-domain/build.gradle
@@ -15,4 +15,5 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
     testImplementation 'com.h2database:h2'
+    testFixturesImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/jabiseo-domain/src/main/java/com/jabiseo/certificate/domain/Certificate.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/certificate/domain/Certificate.java
@@ -33,13 +33,12 @@ public class Certificate {
     @OneToMany(mappedBy = "certificate")
     private List<Subject> subjects = new ArrayList<>();
 
-    private Certificate(Long id, String name) {
-        this.id = id;
+    private Certificate(String name) {
         this.name = name;
     }
 
-    public static Certificate of(Long id, String name) {
-        return new Certificate(id, name);
+    public static Certificate of(String name) {
+        return new Certificate(name);
     }
 
     public void addExam(Exam exam) {

--- a/jabiseo-domain/src/main/java/com/jabiseo/certificate/domain/Certificate.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/certificate/domain/Certificate.java
@@ -20,6 +20,7 @@ public class Certificate {
 
     @Id
     @Column(name = "certificate_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String name;

--- a/jabiseo-domain/src/main/java/com/jabiseo/certificate/domain/Certificate.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/certificate/domain/Certificate.java
@@ -20,7 +20,7 @@ public class Certificate {
 
     @Id
     @Column(name = "certificate_id")
-    private String id;
+    private Long id;
 
     private String name;
 
@@ -32,12 +32,12 @@ public class Certificate {
     @OneToMany(mappedBy = "certificate")
     private List<Subject> subjects = new ArrayList<>();
 
-    private Certificate(String id, String name) {
+    private Certificate(Long id, String name) {
         this.id = id;
         this.name = name;
     }
 
-    public static Certificate of(String id, String name) {
+    public static Certificate of(Long id, String name) {
         return new Certificate(id, name);
     }
 
@@ -49,19 +49,19 @@ public class Certificate {
         subjects.add(subject);
     }
 
-    public boolean containsSubject(String subjectId) {
+    public boolean containsSubject(Long subjectId) {
         return subjects.stream()
                 .map(Subject::getId)
                 .anyMatch(id -> id.equals(subjectId));
     }
 
-    public boolean containsExam(String examId) {
+    public boolean containsExam(Long examId) {
         return exams.stream()
                 .map(Exam::getId)
                 .anyMatch(id -> id.equals(examId));
     }
 
-    private void validateSubjectIds(List<String> subjectIds) {
+    private void validateSubjectIds(List<Long> subjectIds) {
         // 자격증에 해당하는 과목들이 모두 있는지 검사
         subjectIds.forEach(subjectId -> {
             if (!this.containsSubject(subjectId)) {
@@ -70,14 +70,14 @@ public class Certificate {
         });
     }
 
-    private void validateExamId(Optional<String> examId) {
+    private void validateExamId(Optional<Long> examId) {
         // 자격증에 해당하는 시험이 있는지 검사
         if (examId.isPresent() && !this.containsExam(examId.get())) {
             throw new CertificateBusinessException(CertificateErrorCode.EXAM_NOT_FOUND_IN_CERTIFICATE);
         }
     }
 
-    public void validateExamIdAndSubjectIds(Optional<String> examId, List<String> subjectIds) {
+    public void validateExamIdAndSubjectIds(Optional<Long> examId, List<Long> subjectIds) {
         validateExamId(examId);
         validateSubjectIds(subjectIds);
     }

--- a/jabiseo-domain/src/main/java/com/jabiseo/certificate/domain/CertificateRepository.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/certificate/domain/CertificateRepository.java
@@ -2,5 +2,5 @@ package com.jabiseo.certificate.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface CertificateRepository extends JpaRepository<Certificate, String>{
+public interface CertificateRepository extends JpaRepository<Certificate, Long>{
 }

--- a/jabiseo-domain/src/main/java/com/jabiseo/certificate/domain/Exam.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/certificate/domain/Exam.java
@@ -12,7 +12,7 @@ public class Exam {
 
     @Id
     @Column(name = "exam_id")
-    private String id;
+    private Long id;
 
     private String description;
 
@@ -24,7 +24,7 @@ public class Exam {
     @JoinColumn(name = "certificate_id", foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
     private Certificate certificate;
 
-    private Exam(String id, String description, int examYear, int yearRound, Certificate certificate) {
+    private Exam(Long id, String description, int examYear, int yearRound, Certificate certificate) {
         this.id = id;
         this.description = description;
         this.examYear = examYear;
@@ -32,7 +32,7 @@ public class Exam {
         this.certificate = certificate;
     }
 
-    public static Exam of(String id, String description, int examYear, int round, Certificate certificate) {
+    public static Exam of(Long id, String description, int examYear, int round, Certificate certificate) {
         Exam exam = new Exam(id, description, examYear, round, certificate);
         certificate.addExam(exam);
         return exam;

--- a/jabiseo-domain/src/main/java/com/jabiseo/certificate/domain/Exam.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/certificate/domain/Exam.java
@@ -12,6 +12,7 @@ public class Exam {
 
     @Id
     @Column(name = "exam_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String description;

--- a/jabiseo-domain/src/main/java/com/jabiseo/certificate/domain/Exam.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/certificate/domain/Exam.java
@@ -25,16 +25,15 @@ public class Exam {
     @JoinColumn(name = "certificate_id", foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
     private Certificate certificate;
 
-    private Exam(Long id, String description, int examYear, int yearRound, Certificate certificate) {
-        this.id = id;
+    private Exam(String description, int examYear, int yearRound, Certificate certificate) {
         this.description = description;
         this.examYear = examYear;
         this.yearRound = yearRound;
         this.certificate = certificate;
     }
 
-    public static Exam of(Long id, String description, int examYear, int round, Certificate certificate) {
-        Exam exam = new Exam(id, description, examYear, round, certificate);
+    public static Exam of(String description, int examYear, int round, Certificate certificate) {
+        Exam exam = new Exam(description, examYear, round, certificate);
         certificate.addExam(exam);
         return exam;
     }

--- a/jabiseo-domain/src/main/java/com/jabiseo/certificate/domain/Subject.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/certificate/domain/Subject.java
@@ -23,15 +23,14 @@ public class Subject {
     @JoinColumn(name = "certificate_id", foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
     private Certificate certificate;
 
-    private Subject(Long id, String name, int sequence, Certificate certificate) {
-        this.id = id;
+    private Subject(String name, int sequence, Certificate certificate) {
         this.name = name;
         this.sequence = sequence;
         this.certificate = certificate;
     }
 
-    public static Subject of(Long id, String name, int sequence, Certificate certificate) {
-        Subject subject = new Subject(id, name, sequence, certificate);
+    public static Subject of(String name, int sequence, Certificate certificate) {
+        Subject subject = new Subject(name, sequence, certificate);
         certificate.addSubject(subject);
         return subject;
     }

--- a/jabiseo-domain/src/main/java/com/jabiseo/certificate/domain/Subject.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/certificate/domain/Subject.java
@@ -2,7 +2,6 @@ package com.jabiseo.certificate.domain;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -13,7 +12,7 @@ public class Subject {
 
     @Id
     @Column(name = "subject_id")
-    private String id;
+    private Long id;
 
     private String name;
 
@@ -23,14 +22,14 @@ public class Subject {
     @JoinColumn(name = "certificate_id", foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
     private Certificate certificate;
 
-    private Subject(String id, String name, int sequence, Certificate certificate) {
+    private Subject(Long id, String name, int sequence, Certificate certificate) {
         this.id = id;
         this.name = name;
         this.sequence = sequence;
         this.certificate = certificate;
     }
 
-    public static Subject of(String id, String name, int sequence, Certificate certificate) {
+    public static Subject of(Long id, String name, int sequence, Certificate certificate) {
         Subject subject = new Subject(id, name, sequence, certificate);
         certificate.addSubject(subject);
         return subject;

--- a/jabiseo-domain/src/main/java/com/jabiseo/certificate/domain/Subject.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/certificate/domain/Subject.java
@@ -12,6 +12,7 @@ public class Subject {
 
     @Id
     @Column(name = "subject_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String name;

--- a/jabiseo-domain/src/main/java/com/jabiseo/problem/domain/BookmarkRepository.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/problem/domain/BookmarkRepository.java
@@ -6,8 +6,8 @@ import java.util.Optional;
 
 public interface BookmarkRepository extends JpaRepository<Bookmark, String> {
 
-    boolean existsByMemberIdAndProblemId(String memberId, String problemId);
+    boolean existsByMemberIdAndProblemId(String memberId, Long problemId);
 
-    Optional<Bookmark> findByMemberIdAndProblemId(String memberId, String problemId);
+    Optional<Bookmark> findByMemberIdAndProblemId(String memberId, Long problemId);
 
 }

--- a/jabiseo-domain/src/main/java/com/jabiseo/problem/domain/Problem.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/problem/domain/Problem.java
@@ -53,9 +53,8 @@ public class Problem {
         return List.of(choice1, choice2, choice3, choice4);
     }
 
-    private Problem(Long id, String description, String choice1, String choice2, String choice3, String choice4,
+    private Problem(String description, String choice1, String choice2, String choice3, String choice4,
                     int answerNumber, String solution, int sequence, Certificate certificate, Exam exam, Subject subject) {
-        this.id = id;
         this.description = description;
         this.choice1 = choice1;
         this.choice2 = choice2;
@@ -69,9 +68,9 @@ public class Problem {
         this.subject = subject;
     }
 
-    public static Problem of(Long id, String description, String choice1, String choice2, String choice3, String choice4,
+    public static Problem of(String description, String choice1, String choice2, String choice3, String choice4,
                              int answerNumber, String solution, int sequence, Certificate certificate, Exam exam, Subject subject) {
-        return new Problem(id, description, choice1, choice2, choice3, choice4,
+        return new Problem(description, choice1, choice2, choice3, choice4,
                 answerNumber, solution, sequence, certificate, exam, subject);
     }
 

--- a/jabiseo-domain/src/main/java/com/jabiseo/problem/domain/Problem.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/problem/domain/Problem.java
@@ -18,6 +18,7 @@ public class Problem {
 
     @Id
     @Column(name = "problem_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String description;

--- a/jabiseo-domain/src/main/java/com/jabiseo/problem/domain/Problem.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/problem/domain/Problem.java
@@ -18,7 +18,7 @@ public class Problem {
 
     @Id
     @Column(name = "problem_id")
-    private String id;
+    private Long id;
 
     private String description;
 
@@ -52,7 +52,7 @@ public class Problem {
         return List.of(choice1, choice2, choice3, choice4);
     }
 
-    private Problem(String id, String description, String choice1, String choice2, String choice3, String choice4,
+    private Problem(Long id, String description, String choice1, String choice2, String choice3, String choice4,
                     int answerNumber, String solution, int sequence, Certificate certificate, Exam exam, Subject subject) {
         this.id = id;
         this.description = description;
@@ -68,7 +68,7 @@ public class Problem {
         this.subject = subject;
     }
 
-    public static Problem of(String id, String description, String choice1, String choice2, String choice3, String choice4,
+    public static Problem of(Long id, String description, String choice1, String choice2, String choice3, String choice4,
                              int answerNumber, String solution, int sequence, Certificate certificate, Exam exam, Subject subject) {
         return new Problem(id, description, choice1, choice2, choice3, choice4,
                 answerNumber, solution, sequence, certificate, exam, subject);

--- a/jabiseo-domain/src/main/java/com/jabiseo/problem/domain/ProblemRepository.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/problem/domain/ProblemRepository.java
@@ -7,19 +7,19 @@ import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
-public interface ProblemRepository extends JpaRepository<Problem, String> {
+public interface ProblemRepository extends JpaRepository<Problem, Long> {
 
     // TODO: rand() 쿼리를 native로 하는 것은 성능상 좋지 않음. 추후 수정 필요
     @Query(value = "select * from problem where exam_id = :examId and subject_id = :subjectId order by rand() limit :count", nativeQuery = true)
-    List<Problem> findRandomByExamIdAndSubjectId(String examId, String subjectId, int count);
+    List<Problem> findRandomByExamIdAndSubjectId(Long examId, Long subjectId, int count);
 
     // TODO: rand() 쿼리를 native로 하는 것은 성능상 좋지 않음. 추후 수정 필요
     @Query(value = "select * from problem where subject_id = :subjectId order by rand() limit :count", nativeQuery = true)
-    List<Problem> findRandomBySubjectId(String subjectId, int count);
+    List<Problem> findRandomBySubjectId(Long subjectId, int count);
 
     @Query(value = "select p from Bookmark b join b.problem p where b.member.id = :memberId and p.exam.id = :examId and p.subject.id in :subjectIds")
-    Page<Problem> findBookmarkedByExamIdAndSubjectIdIn(String memberId, String examId, List<String> subjectIds, Pageable pageable);
+    Page<Problem> findBookmarkedByExamIdAndSubjectIdIn(String memberId, Long examId, List<Long> subjectIds, Pageable pageable);
 
     @Query(value = "select p from Bookmark b join b.problem p where b.member.id = :memberId and p.subject.id in :subjectIds")
-    Page<Problem> findBookmarkedBySubjectIdIn(String memberId, List<String> subjectIds, Pageable pageable);
+    Page<Problem> findBookmarkedBySubjectIdIn(String memberId, List<Long> subjectIds, Pageable pageable);
 }

--- a/jabiseo-domain/src/test/java/com/jabiseo/certificate/domain/CertificateTest.java
+++ b/jabiseo-domain/src/test/java/com/jabiseo/certificate/domain/CertificateTest.java
@@ -24,9 +24,9 @@ class CertificateTest {
     @DisplayName("시험 id와 과목 id 리스트가 모두 적절하면 예외를 반환하지 않는다.")
     void givenExamIdAndSubjectIdList_whenValidateInput_thenDoNotReturnError() {
         //given
-        String certificateId = "1";
-        String examId = "2";
-        List<String> subjectIdList = List.of("3", "4");
+        Long certificateId = 1L;
+        Long examId = 2L;
+        List<Long> subjectIdList = List.of(3L, 4L);
 
         Certificate certificate = createCertificate(certificateId);
         createExam(examId, certificate);
@@ -40,8 +40,8 @@ class CertificateTest {
     @DisplayName("시험 id가 없고 과목 id 리스트가 적절하면 예외를 반환하지 않는다.")
     void givenSubjectIdList_whenValidateInput_thenDoNotReturnError() {
         //given
-        String certificateId = "1";
-        List<String> subjectIdList = List.of("3", "4");
+        Long certificateId = 1L;
+        List<Long> subjectIdList = List.of(3L, 4L);
 
         Certificate certificate = createCertificate(certificateId);
         subjectIdList.forEach(subjectId -> createSubject(subjectId, certificate));
@@ -54,10 +54,10 @@ class CertificateTest {
     @DisplayName("시험 id가 자격증과 관련이 없으면 예외를 반환한다.")
     void givenInvalidExamIdAndSubjectIdList_whenValidateInput_thenReturnError() {
         //given
-        String certificateId = "1";
-        String examId = "2";
-        String invalidExamId = "100";
-        List<String> subjectIdList = List.of("3", "4");
+        Long certificateId = 1L;
+        Long examId = 2L;
+        Long invalidExamId = 100L;
+        List<Long> subjectIdList = List.of(3L, 4L);
 
         Certificate certificate = createCertificate(certificateId);
         createExam(examId, certificate);
@@ -73,10 +73,10 @@ class CertificateTest {
     @DisplayName("과목 id 리스트가 자격증과 관련이 없으면 예외를 반환한다.")
     void givenExamIdAndInvalidSubjectIdList_whenValidateInput_thenReturnError() {
         //given
-        String certificateId = "1";
-        String examId = "2";
-        List<String> subjectIdList = List.of("3", "4");
-        List<String> invalidSubjectIdList = List.of("100");
+        Long certificateId = 1L;
+        Long examId = 2L;
+        List<Long> subjectIdList = List.of(3L, 4L);
+        List<Long> invalidSubjectIdList = List.of(100L);
 
         Certificate certificate = createCertificate(certificateId);
         createExam(examId, certificate);

--- a/jabiseo-domain/src/test/java/com/jabiseo/member/domain/MemberTest.java
+++ b/jabiseo-domain/src/test/java/com/jabiseo/member/domain/MemberTest.java
@@ -22,7 +22,7 @@ class MemberTest {
     void givenMember_whenValidateCurrentCertificate_thenDoesNotThrowException() {
         //given
         String memberId = "1";
-        String certificateId = "2";
+        Long certificateId = 2L;
         Member member = createMember(memberId);
         Certificate certificate = createCertificate(certificateId);
         member.updateCurrentCertificate(certificate);

--- a/jabiseo-domain/src/test/java/com/jabiseo/problem/domain/ProblemRepositoryTest.java
+++ b/jabiseo-domain/src/test/java/com/jabiseo/problem/domain/ProblemRepositoryTest.java
@@ -41,9 +41,9 @@ class ProblemRepositoryTest {
 
     private String memberId;
     private Member member;
-    private List<String> examId;
-    private List<String> subjectId;
-    private List<String> problemIds;
+    private List<Long> examId;
+    private List<Long> subjectId;
+    private List<Long> problemIds;
     private Certificate certificate;
     private List<Exam> exams;
     private List<Subject> subjects;
@@ -52,10 +52,10 @@ class ProblemRepositoryTest {
     void setUp() {
         //given
         memberId = "memberId";
-        String certificateId = "certificateId";
-        examId = List.of("examId1", "examId2");
-        subjectId = List.of("subjectId1", "subjectId2", "subjectId3");
-        problemIds = List.of("pid1", "pid2", "pid3", "pid4", "pid5", "pid6", "pid7", "pid8", "pid9", "pid10", "pid11");
+        Long certificateId = 100L;
+        examId = List.of(200L, 300L);
+        subjectId = List.of(400L, 500L, 600L);
+        problemIds = List.of(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L, 11L);
 
         member = createMember(memberId);
         certificate = createCertificate(certificateId);

--- a/jabiseo-domain/src/test/java/com/jabiseo/problem/domain/ProblemTest.java
+++ b/jabiseo-domain/src/test/java/com/jabiseo/problem/domain/ProblemTest.java
@@ -21,8 +21,10 @@ class ProblemTest {
     @DisplayName("문제 검사 시 파라미터로 들어온 자격증이 문제의 자격증에 해당하면 예외가 발생하지 않는다.")
     void givenCertificateAndProblem_whenValidateProblem_thenDoesNotReturnError() {
         //given
-        Certificate certificate = createCertificate("1");
-        Problem problem = createProblem("2", certificate);
+        Long certificateId = 1L;
+        Long problemId = 2L;
+        Certificate certificate = createCertificate(certificateId);
+        Problem problem = createProblem(problemId, certificate);
 
         //when & then
         assertDoesNotThrow(() -> problem.validateProblemInCertificate(certificate));
@@ -32,9 +34,12 @@ class ProblemTest {
     @DisplayName("문제 검사 시 파라미터로 들어온 자격증이 문제의 자격증에 해당하지 않으면 예외가 발생한다.")
     void givenInvalidCertificateAndProblem_whenValidateProblem_thenReturnError() {
         //given
-        Certificate certificate = createCertificate("1");
-        Certificate invalidCertificate = createCertificate("100");
-        Problem problem = createProblem("2", certificate);
+        Long certificateId = 1L;
+        Long invalidCertificateId = 100L;
+        Long problemId = 2L;
+        Certificate certificate = createCertificate(certificateId);
+        Certificate invalidCertificate = createCertificate(invalidCertificateId);
+        Problem problem = createProblem(problemId, certificate);
 
         //when & then
         assertThatThrownBy(() -> problem.validateProblemInCertificate(invalidCertificate))

--- a/jabiseo-domain/src/testFixtures/java/fixture/CertificateFixture.java
+++ b/jabiseo-domain/src/testFixtures/java/fixture/CertificateFixture.java
@@ -4,7 +4,7 @@ import com.jabiseo.certificate.domain.Certificate;
 
 public class CertificateFixture {
 
-    public static Certificate createCertificate(String certificateId) {
+    public static Certificate createCertificate(Long certificateId) {
         return Certificate.of(certificateId, "certificate name");
     }
 

--- a/jabiseo-domain/src/testFixtures/java/fixture/CertificateFixture.java
+++ b/jabiseo-domain/src/testFixtures/java/fixture/CertificateFixture.java
@@ -1,11 +1,18 @@
 package fixture;
 
 import com.jabiseo.certificate.domain.Certificate;
+import org.springframework.test.util.ReflectionTestUtils;
 
 public class CertificateFixture {
 
     public static Certificate createCertificate(Long certificateId) {
-        return Certificate.of(certificateId, "certificate name");
+        Certificate certificate = Certificate.of("certificate name");
+        ReflectionTestUtils.setField(certificate, "id", certificateId);
+        return certificate;
+    }
+
+    public static Certificate createCertificate() {
+        return Certificate.of("certificate name");
     }
 
 }

--- a/jabiseo-domain/src/testFixtures/java/fixture/ExamFixture.java
+++ b/jabiseo-domain/src/testFixtures/java/fixture/ExamFixture.java
@@ -2,11 +2,18 @@ package fixture;
 
 import com.jabiseo.certificate.domain.Certificate;
 import com.jabiseo.certificate.domain.Exam;
+import org.springframework.test.util.ReflectionTestUtils;
 
 public class ExamFixture {
 
     public static Exam createExam(Long examId, Certificate certificate) {
-        return Exam.of(examId, "exam description", 2000, 1, certificate);
+        Exam exam =  Exam.of("exam description", 2000, 1, certificate);
+        ReflectionTestUtils.setField(exam, "id", examId);
+        return exam;
+    }
+
+    public static Exam createExam(Certificate certificate) {
+        return Exam.of("exam description", 2000, 1, certificate);
     }
 
 }

--- a/jabiseo-domain/src/testFixtures/java/fixture/ExamFixture.java
+++ b/jabiseo-domain/src/testFixtures/java/fixture/ExamFixture.java
@@ -5,7 +5,7 @@ import com.jabiseo.certificate.domain.Exam;
 
 public class ExamFixture {
 
-    public static Exam createExam(String examId, Certificate certificate) {
+    public static Exam createExam(Long examId, Certificate certificate) {
         return Exam.of(examId, "exam description", 2000, 1, certificate);
     }
 

--- a/jabiseo-domain/src/testFixtures/java/fixture/ProblemFixture.java
+++ b/jabiseo-domain/src/testFixtures/java/fixture/ProblemFixture.java
@@ -4,15 +4,14 @@ import com.jabiseo.certificate.domain.Certificate;
 import com.jabiseo.certificate.domain.Exam;
 import com.jabiseo.certificate.domain.Subject;
 import com.jabiseo.problem.domain.Problem;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import static fixture.CertificateFixture.createCertificate;
-import static fixture.ExamFixture.createExam;
 import static fixture.SubjectFixture.createSubject;
 
 public class ProblemFixture {
     public static Problem createProblem(Long id, Certificate certificate, Exam exam, Subject subject) {
-        return Problem.of(
-                id,
+        Problem problem = Problem.of(
                 "problem description",
                 "choice1",
                 "choice2",
@@ -25,29 +24,21 @@ public class ProblemFixture {
                 exam,
                 subject
         );
+        ReflectionTestUtils.setField(problem, "id", id);
+        return problem;
     }
+
     public static Problem createProblem(Long id, Certificate certificate) {
-        return Problem.of(
-                id,
-                "problem description",
-                "choice1",
-                "choice2",
-                "choice3",
-                "choice4",
-                1,
-                "problem theory",
-                1,
-                certificate,
-                createExam(5432L, certificate),
-                createSubject(9876L, certificate)
-        );
+        return createProblem(id, certificate, ExamFixture.createExam(5432L, certificate), createSubject(9876L, certificate));
     }
 
 
     public static Problem createProblem(Long id) {
-        Certificate certificate = createCertificate(1234L);
+        return createProblem(id, createCertificate(1234L));
+    }
+
+    public static Problem createProblem(Certificate certificate, Exam exam, Subject subject) {
         return Problem.of(
-                id,
                 "problem description",
                 "choice1",
                 "choice2",
@@ -57,8 +48,8 @@ public class ProblemFixture {
                 "problem theory",
                 1,
                 certificate,
-                createExam(5432L, certificate),
-                createSubject(9876L, certificate)
+                exam,
+                subject
         );
     }
 }

--- a/jabiseo-domain/src/testFixtures/java/fixture/ProblemFixture.java
+++ b/jabiseo-domain/src/testFixtures/java/fixture/ProblemFixture.java
@@ -10,7 +10,7 @@ import static fixture.ExamFixture.createExam;
 import static fixture.SubjectFixture.createSubject;
 
 public class ProblemFixture {
-    public static Problem createProblem(String id, Certificate certificate, Exam exam, Subject subject) {
+    public static Problem createProblem(Long id, Certificate certificate, Exam exam, Subject subject) {
         return Problem.of(
                 id,
                 "problem description",
@@ -26,7 +26,7 @@ public class ProblemFixture {
                 subject
         );
     }
-    public static Problem createProblem(String id, Certificate certificate) {
+    public static Problem createProblem(Long id, Certificate certificate) {
         return Problem.of(
                 id,
                 "problem description",
@@ -38,14 +38,14 @@ public class ProblemFixture {
                 "problem theory",
                 1,
                 certificate,
-                createExam("5432", certificate),
-                createSubject("9876", certificate)
+                createExam(5432L, certificate),
+                createSubject(9876L, certificate)
         );
     }
 
 
-    public static Problem createProblem(String id) {
-        Certificate certificate = createCertificate("1234");
+    public static Problem createProblem(Long id) {
+        Certificate certificate = createCertificate(1234L);
         return Problem.of(
                 id,
                 "problem description",
@@ -57,8 +57,8 @@ public class ProblemFixture {
                 "problem theory",
                 1,
                 certificate,
-                createExam("5432", certificate),
-                createSubject("9876", certificate)
+                createExam(5432L, certificate),
+                createSubject(9876L, certificate)
         );
     }
 }

--- a/jabiseo-domain/src/testFixtures/java/fixture/SubjectFixture.java
+++ b/jabiseo-domain/src/testFixtures/java/fixture/SubjectFixture.java
@@ -5,7 +5,7 @@ import com.jabiseo.certificate.domain.Subject;
 
 public class SubjectFixture {
 
-    public static Subject createSubject(String subjectId, Certificate certificate) {
+    public static Subject createSubject(Long subjectId, Certificate certificate) {
         return Subject.of(subjectId, "subject name", 1, certificate);
     }
 

--- a/jabiseo-domain/src/testFixtures/java/fixture/SubjectFixture.java
+++ b/jabiseo-domain/src/testFixtures/java/fixture/SubjectFixture.java
@@ -2,11 +2,18 @@ package fixture;
 
 import com.jabiseo.certificate.domain.Certificate;
 import com.jabiseo.certificate.domain.Subject;
+import org.springframework.test.util.ReflectionTestUtils;
 
 public class SubjectFixture {
 
     public static Subject createSubject(Long subjectId, Certificate certificate) {
-        return Subject.of(subjectId, "subject name", 1, certificate);
+        Subject subject = Subject.of("subject name", 1, certificate);
+        ReflectionTestUtils.setField(subject, "id", subjectId);
+        return subject;
+    }
+
+    public static Subject createSubject(Certificate certificate) {
+        return Subject.of("subject name", 1, certificate);
     }
 
 }


### PR DESCRIPTION
## PR 변경된 내용
현재는 PK가 모두 String 형으로 되어 있다.
여기에는 두 가지 관점이 있었다.

Auto Increasement로 할 경우 해당 데이터가 몇 번째인지 등이 그대로 노출된다. UUID를 써서 보안을 상승시킨다.
서비스가 커져 많은 insert를 처리할 때에는 Auto Increasement가 데이터베이스에 lock을 걸어 문제의 원인이 된다. WAS에서 key를 생성해 DB가 key를 관리하지 않도록 하자.
이와 같은 관점에서, 문제이나 자격증 같은 데이터들은 개발자들이 직접 데이터베이스에 넣으므로 위의 문제들과 크게 상관이 없다.
따라서 밑의 개발자가 직접 데이터를 넣는 테이블의 pk는 bigint 로 전환한다.

Certificate (자격증)
Exam (시험)
Subject (과목)
Problem (문제)

**생성자 수정**
관련된 생성자도 id값이 들어가지 않고 생성되도록 변경

## 추가 내용
### 관련된 test 수정
- 생성자 변경으로 인한 ReflectionTestUtils 클래스 사용
- testFixtures 패키지에만 적용되도록 build.gradle에 testFixturesImplementation 사용

## 참조
Closes #40 
