### PR TITLE
Feat(*): 결과 제출 API 구현

### DIFF
--- a/jabiseo-api/src/main/java/com/jabiseo/auth/dto/LoginRequest.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/auth/dto/LoginRequest.java
@@ -7,6 +7,7 @@ import jakarta.validation.constraints.NotNull;
 public record LoginRequest(
         @NotNull
         String idToken,
-        @EnumValid(enumClass = OauthServer.class, message = "oauthServer Type이 잘못됐습니다.")
-        String oauthServer) {
+        @EnumValid(enumClass = OauthServer.class, message = "oauthServer Type이 올바르지 않습니다.")
+        String oauthServer
+) {
 }

--- a/jabiseo-api/src/main/java/com/jabiseo/learning/application/usecase/CreateLearningUseCase.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/learning/application/usecase/CreateLearningUseCase.java
@@ -39,6 +39,8 @@ public class CreateLearningUseCase {
         Certificate certificate = certificateRepository.findById(request.certificateId())
                 .orElseThrow(() -> new CertificateBusinessException(CertificateErrorCode.CERTIFICATE_NOT_FOUND));
 
+        validateDuplicatedSolving(request);
+
         Learning learning = Learning.of(LearningMode.valueOf(request.learningMode()), request.learningTime(), certificate);
         learningRepository.save(learning);
 
@@ -53,6 +55,12 @@ public class CreateLearningUseCase {
         problemSolvingRepository.saveAll(problemSolvings);
 
         return learning.getId();
+    }
+
+    private static void validateDuplicatedSolving(CreateLearningRequest request) {
+        if (request.problems().stream().distinct().count() != request.problems().size()) {
+            throw new ProblemBusinessException(ProblemErrorCode.DUPLICATED_SOLVING_PROBLEM);
+        }
     }
 
     private List<Problem> findSolvedProblems(CreateLearningRequest request) {

--- a/jabiseo-api/src/main/java/com/jabiseo/learning/application/usecase/CreateLearningUseCase.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/learning/application/usecase/CreateLearningUseCase.java
@@ -1,12 +1,73 @@
 package com.jabiseo.learning.application.usecase;
 
+import com.jabiseo.certificate.domain.Certificate;
+import com.jabiseo.certificate.domain.CertificateRepository;
+import com.jabiseo.certificate.exception.CertificateBusinessException;
+import com.jabiseo.certificate.exception.CertificateErrorCode;
+import com.jabiseo.learning.domain.Learning;
+import com.jabiseo.learning.domain.LearningRepository;
+import com.jabiseo.learning.domain.ProblemSolving;
+import com.jabiseo.learning.domain.ProblemSolvingRepository;
 import com.jabiseo.learning.dto.CreateLearningRequest;
+import com.jabiseo.learning.dto.ProblemResultRequest;
+import com.jabiseo.member.domain.Member;
+import com.jabiseo.member.domain.MemberRepository;
+import com.jabiseo.member.exception.MemberBusinessException;
+import com.jabiseo.member.exception.MemberErrorCode;
+import com.jabiseo.problem.domain.Problem;
+import com.jabiseo.problem.domain.ProblemRepository;
+import com.jabiseo.problem.exception.ProblemBusinessException;
+import com.jabiseo.problem.exception.ProblemErrorCode;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
+@RequiredArgsConstructor
+@Transactional
 public class CreateLearningUseCase {
 
-    public void execute(CreateLearningRequest request) {
-        return;
+    private final MemberRepository memberRepository;
+    private final CertificateRepository certificateRepository;
+    private final ProblemRepository problemRepository;
+    private final LearningRepository learningRepository;
+    private final ProblemSolvingRepository problemSolvingRepository;
+
+    public Long execute(Long memberId, CreateLearningRequest request) {
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberBusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        Certificate certificate = certificateRepository.findById(request.certificateId())
+                .orElseThrow(() -> new CertificateBusinessException(CertificateErrorCode.CERTIFICATE_NOT_FOUND));
+
+        Learning learning = Learning.of(request.learningMode(), request.learningTime(), certificate);
+        learningRepository.save(learning);
+
+        //문제들의 id 리스트를 뽑아내 한 번의 쿼리로 찾아옴
+        List<Long> solvedProblemIds = request.problems().stream()
+                .map(ProblemResultRequest::problemId)
+                .toList();
+        List<Problem> solvedProblems = problemRepository.findAllById(solvedProblemIds);
+
+        //요청 개수와 실제 데이터 개수가 다르면 옳지 않은 문제 ID가 요청되었다는 것
+        if (solvedProblems.size() != request.problems().size()) {
+            throw new ProblemBusinessException(ProblemErrorCode.PROBLEM_NOT_FOUND);
+        }
+        solvedProblems.forEach(problem -> problem.validateProblemInCertificate(certificate));
+
+        //ProblemSolving 생성 및 저장
+        List<ProblemSolving> problemSolvings = new ArrayList<>();
+        for (int i = 0; i < solvedProblems.size(); i++) {
+            boolean isCorrect = solvedProblems.get(i).checkAnswer(request.problems().get(i).choice());
+            ProblemSolving problemSolving = ProblemSolving.of(member, solvedProblems.get(i), learning, request.problems().get(i).choice(), isCorrect);
+            problemSolvings.add(problemSolving);
+        }
+        problemSolvingRepository.saveAll(problemSolvings);
+
+        return learning.getId();
     }
 }

--- a/jabiseo-api/src/main/java/com/jabiseo/learning/application/usecase/CreateLearningUseCase.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/learning/application/usecase/CreateLearningUseCase.java
@@ -12,8 +12,6 @@ import com.jabiseo.learning.dto.CreateLearningRequest;
 import com.jabiseo.learning.dto.ProblemResultRequest;
 import com.jabiseo.member.domain.Member;
 import com.jabiseo.member.domain.MemberRepository;
-import com.jabiseo.member.exception.MemberBusinessException;
-import com.jabiseo.member.exception.MemberErrorCode;
 import com.jabiseo.problem.domain.Problem;
 import com.jabiseo.problem.domain.ProblemRepository;
 import com.jabiseo.problem.exception.ProblemBusinessException;
@@ -38,8 +36,7 @@ public class CreateLearningUseCase {
 
     public Long execute(Long memberId, CreateLearningRequest request) {
 
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new MemberBusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
+        Member member = memberRepository.getReferenceById(memberId);
 
         Certificate certificate = certificateRepository.findById(request.certificateId())
                 .orElseThrow(() -> new CertificateBusinessException(CertificateErrorCode.CERTIFICATE_NOT_FOUND));

--- a/jabiseo-api/src/main/java/com/jabiseo/learning/application/usecase/CreateLearningUseCase.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/learning/application/usecase/CreateLearningUseCase.java
@@ -4,10 +4,7 @@ import com.jabiseo.certificate.domain.Certificate;
 import com.jabiseo.certificate.domain.CertificateRepository;
 import com.jabiseo.certificate.exception.CertificateBusinessException;
 import com.jabiseo.certificate.exception.CertificateErrorCode;
-import com.jabiseo.learning.domain.Learning;
-import com.jabiseo.learning.domain.LearningRepository;
-import com.jabiseo.learning.domain.ProblemSolving;
-import com.jabiseo.learning.domain.ProblemSolvingRepository;
+import com.jabiseo.learning.domain.*;
 import com.jabiseo.learning.dto.CreateLearningRequest;
 import com.jabiseo.learning.dto.ProblemResultRequest;
 import com.jabiseo.member.domain.Member;
@@ -42,7 +39,7 @@ public class CreateLearningUseCase {
         Certificate certificate = certificateRepository.findById(request.certificateId())
                 .orElseThrow(() -> new CertificateBusinessException(CertificateErrorCode.CERTIFICATE_NOT_FOUND));
 
-        Learning learning = Learning.of(request.learningMode(), request.learningTime(), certificate);
+        Learning learning = Learning.of(LearningMode.valueOf(request.learningMode()), request.learningTime(), certificate);
         learningRepository.save(learning);
 
         //문제들의 id 리스트를 뽑아내 한 번의 쿼리로 찾아옴

--- a/jabiseo-api/src/main/java/com/jabiseo/learning/controller/LearningController.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/learning/controller/LearningController.java
@@ -1,13 +1,19 @@
 package com.jabiseo.learning.controller;
 
+import com.jabiseo.config.auth.AuthMember;
+import com.jabiseo.config.auth.AuthenticatedMember;
 import com.jabiseo.learning.dto.CreateLearningRequest;
 import com.jabiseo.learning.application.usecase.CreateLearningUseCase;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.net.URI;
 
 @RestController
 @RequiredArgsConstructor
@@ -18,9 +24,17 @@ public class LearningController {
 
     @PostMapping
     public ResponseEntity<Void> createLearning(
-            @RequestBody CreateLearningRequest request
+            @AuthenticatedMember AuthMember member,
+            @RequestBody @Valid CreateLearningRequest request
     ) {
-        createLearningUseCase.execute(request);
+        Long learningId = createLearningUseCase.execute(member.getMemberId(), request);
+
+        URI location = ServletUriComponentsBuilder
+                .fromCurrentRequest()
+                .path("/{id}")
+                .buildAndExpand(learningId)
+                .toUri();
+
         return ResponseEntity.noContent().build();
     }
 }

--- a/jabiseo-api/src/main/java/com/jabiseo/learning/controller/LearningController.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/learning/controller/LearningController.java
@@ -35,6 +35,6 @@ public class LearningController {
                 .buildAndExpand(learningId)
                 .toUri();
 
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.created(location).build();
     }
 }

--- a/jabiseo-api/src/main/java/com/jabiseo/learning/dto/CreateLearningRequest.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/learning/dto/CreateLearningRequest.java
@@ -15,7 +15,7 @@ public record CreateLearningRequest(
         Long learningTime,
 
         @EnumValid(enumClass = LearningMode.class, message = "학습 모드가 올바르지 않습니다.")
-        LearningMode learningMode,
+        String learningMode,
 
         @NotNull(message = "자격증 ID를 입력해야 합니다.")
         Long certificateId,

--- a/jabiseo-api/src/main/java/com/jabiseo/learning/dto/CreateLearningRequest.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/learning/dto/CreateLearningRequest.java
@@ -1,16 +1,25 @@
 package com.jabiseo.learning.dto;
 
+import com.jabiseo.common.validator.EnumValid;
 import com.jabiseo.learning.domain.LearningMode;
+import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 
 import java.util.List;
 
 public record CreateLearningRequest(
         @Min(value = 1L, message = "학습 시간은 0보다 커야 합니다.")
+        @Max(value = 1000000000L, message = "학습 시간이 비정상적으로 큽니다.")
         Long learningTime,
+
+        @EnumValid(enumClass = LearningMode.class, message = "학습 모드가 올바르지 않습니다.")
         LearningMode learningMode,
+
+        @NotNull(message = "자격증 ID를 입력해야 합니다.")
         Long certificateId,
+
         @NotEmpty(message = "문제를 풀어야 합니다.")
         List<ProblemResultRequest> problems
 ) {

--- a/jabiseo-api/src/main/java/com/jabiseo/learning/dto/CreateLearningRequest.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/learning/dto/CreateLearningRequest.java
@@ -1,10 +1,17 @@
 package com.jabiseo.learning.dto;
 
 import com.jabiseo.learning.domain.LearningMode;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotEmpty;
+
+import java.util.List;
 
 public record CreateLearningRequest(
-        long studyTime,
+        @Min(value = 1L, message = "학습 시간은 0보다 커야 합니다.")
+        Long learningTime,
         LearningMode learningMode,
-        ProblemResultRequest problems
+        Long certificateId,
+        @NotEmpty(message = "문제를 풀어야 합니다.")
+        List<ProblemResultRequest> problems
 ) {
 }

--- a/jabiseo-api/src/main/java/com/jabiseo/learning/dto/ProblemResultRequest.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/learning/dto/ProblemResultRequest.java
@@ -1,8 +1,12 @@
 package com.jabiseo.learning.dto;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+
 public record ProblemResultRequest(
-        String problemId,
-        int choiceNumber,
-        boolean isCorrect
+        Long problemId,
+        @Min(value = 1L, message = "선지는 1번부터 4번까지 존재합니다.")
+        @Max(value = 4L, message = "선지는 1번부터 4번까지 존재합니다.")
+        int choice
 ) {
 }

--- a/jabiseo-api/src/main/java/com/jabiseo/learning/dto/ProblemResultRequest.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/learning/dto/ProblemResultRequest.java
@@ -2,9 +2,12 @@ package com.jabiseo.learning.dto;
 
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 
 public record ProblemResultRequest(
+        @NotNull(message = "문제 ID를 입력해야 합니다.")
         Long problemId,
+
         @Min(value = 1L, message = "선지는 1번부터 4번까지 존재합니다.")
         @Max(value = 4L, message = "선지는 1번부터 4번까지 존재합니다.")
         int choice

--- a/jabiseo-api/src/main/java/com/jabiseo/problem/application/usecase/FindProblemsByIdUseCase.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/problem/application/usecase/FindProblemsByIdUseCase.java
@@ -29,15 +29,20 @@ public class FindProblemsByIdUseCase {
         member.validateCurrentCertificate();
         Certificate certificate = member.getCurrentCertificate();
 
+        List<Long> problemIds = request.problemIds()
+                .stream()
+                .distinct()
+                .toList();
+
         CertificateResponse certificateResponse = CertificateResponse.from(certificate);
         List<ProblemsDetailResponse> problemsDetailResponses =
-                problemRepository.findDetailByIdsInWithBookmark(memberId, request.problemIds())
+                problemRepository.findDetailByIdsInWithBookmark(memberId, problemIds)
                 .stream()
                 .map(ProblemsDetailResponse::from)
                 .toList();
 
         //요청 개수와 실제 데이터 개수가 다르면 옳지 않은 문제 ID가 요청되었다는 것
-        if (problemsDetailResponses.size() != request.problemIds().size()) {
+        if (problemsDetailResponses.size() != problemIds.size()) {
             throw new ProblemBusinessException(ProblemErrorCode.PROBLEM_NOT_FOUND);
         }
 

--- a/jabiseo-api/src/main/java/com/jabiseo/problem/application/usecase/FindProblemsUseCase.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/problem/application/usecase/FindProblemsUseCase.java
@@ -35,6 +35,7 @@ public class FindProblemsUseCase {
 
         // TODO: 과목별로 문제를 가져와서 쿼리를 5번 날리는 로직에서 1번의 쿼리로 변경해야 함. 하지만 최종적으로 과목 순서가 유지되어야 함
         List<ProblemWithBookmarkDetailQueryDto> problemWithBookmarkDetailQueryDtos = subjectIds.stream()
+                .distinct()
                 .map(subjectId -> problemRepository.findDetailRandomByExamIdAndSubjectIdWithBookmark(memberId, examId, subjectId, count))
                 .flatMap(List::stream)
                 .toList();

--- a/jabiseo-api/src/test/java/com/jabiseo/auth/dto/LoginRequestTest.java
+++ b/jabiseo-api/src/test/java/com/jabiseo/auth/dto/LoginRequestTest.java
@@ -42,7 +42,7 @@ class LoginRequestTest {
         assertThat(violations).isNotEmpty();
     }
 
-    @DisplayName("login 요청시 oauthServer에 정확한 값이 오지 않으면 예외를 반환한다,")
+    @DisplayName("login 요청시 oauthServer에 정확한 값이 오지 않으면 예외를 반환한다.")
     @ParameterizedTest
     @ValueSource(strings = {"kakao", "kakakkao", "", "value", "ggogo", "KAKAOOO"})
     void oauthServerNotAllowInputsThrowException(String oauthServer) {
@@ -63,9 +63,10 @@ class LoginRequestTest {
         //given
         String idToken = "IdTokens..";
         LoginRequest loginRequest = new LoginRequest(idToken, oauthServer);
-        //when
 
+        //when
         Set<ConstraintViolation<LoginRequest>> violations = validator.validate(loginRequest);
+
         //then
         assertThat(violations).isEmpty();
     }

--- a/jabiseo-api/src/test/java/com/jabiseo/learning/application/usecase/CreateLearningUseCaseTest.java
+++ b/jabiseo-api/src/test/java/com/jabiseo/learning/application/usecase/CreateLearningUseCaseTest.java
@@ -127,6 +127,29 @@ class CreateLearningUseCaseTest {
     }
 
     @Test
+    @DisplayName("한 문제를 여러 번 풀었다는 결과가 주어지면 예외가 발생한다.")
+    void givenDuplicatedProblem_whenCreateLearning_thenThrowsException() {
+        //given
+        Long learningTime = 100L;
+        Long memberId = 1L;
+        Long certificateId = 2L;
+        List<Long> problemIds = List.of(3L, 3L);
+
+        Certificate certificate = createCertificate(certificateId);
+        List<Problem> problems = problemIds.stream().map(problemId -> createProblem(problemId, certificate)).toList();
+
+        given(certificateRepository.findById(certificateId)).willReturn(Optional.of(certificate));
+
+        CreateLearningRequest request = new CreateLearningRequest(learningTime, "EXAM", certificateId,
+                problems.stream().map(problem -> new ProblemResultRequest(problem.getId(), 1)).toList());
+
+        //when
+        assertThatThrownBy(() -> sut.execute(memberId, request))
+                .isInstanceOf(ProblemBusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ProblemErrorCode.DUPLICATED_SOLVING_PROBLEM);
+    }
+
+    @Test
     @DisplayName("문제 풀이 결과가 주어지면 학습 결과 생성에 성공한다.")
     void givenResultOfProblemSolving_whenCreateLearning_thenCreateLearning() {
         //given

--- a/jabiseo-api/src/test/java/com/jabiseo/learning/application/usecase/CreateLearningUseCaseTest.java
+++ b/jabiseo-api/src/test/java/com/jabiseo/learning/application/usecase/CreateLearningUseCaseTest.java
@@ -64,7 +64,7 @@ class CreateLearningUseCaseTest {
         Long memberId = 1L;
         Long certificateId = 2L;
         Member member = createMember(memberId);
-        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+        given(memberRepository.getReferenceById(memberId)).willReturn(member);
         CreateLearningRequest request = new CreateLearningRequest(learningTime, "EXAM", certificateId, List.of());
 
         //when & then
@@ -84,7 +84,7 @@ class CreateLearningUseCaseTest {
         Member member = createMember(memberId);
         Certificate certificate = createCertificate(certificateId);
         List<Problem> problems = problemIds.stream().map(problemId -> createProblem(problemId, certificate)).toList();
-        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+        given(memberRepository.getReferenceById(memberId)).willReturn(member);
         given(certificateRepository.findById(certificateId)).willReturn(Optional.of(certificate));
         given(problemRepository.findAllById(problemIds)).willReturn(List.of());
 
@@ -113,7 +113,7 @@ class CreateLearningUseCaseTest {
         Certificate anotherCertificate = createCertificate(anotherCertificateId);
         List<Problem> problems = problemIds.stream().map(problemId -> createProblem(problemId, anotherCertificate)).toList();
 
-        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+        given(memberRepository.getReferenceById(memberId)).willReturn(member);
         given(certificateRepository.findById(certificateId)).willReturn(Optional.of(certificate));
         given(problemRepository.findAllById(problemIds)).willReturn(problems);
 
@@ -164,7 +164,7 @@ class CreateLearningUseCaseTest {
         List<Problem> problems = problemIds.stream().map(problemId -> createProblem(problemId, certificate)).toList();
         Learning learning = createLearning(learningId, certificate);
 
-        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+        given(memberRepository.getReferenceById(memberId)).willReturn(member);
         given(certificateRepository.findById(certificateId)).willReturn(Optional.of(certificate));
         given(problemRepository.findAllById(problemIds)).willReturn(problems);
         given(problemSolvingRepository.saveAll(any())).willReturn(List.of());

--- a/jabiseo-api/src/test/java/com/jabiseo/learning/application/usecase/CreateLearningUseCaseTest.java
+++ b/jabiseo-api/src/test/java/com/jabiseo/learning/application/usecase/CreateLearningUseCaseTest.java
@@ -1,0 +1,168 @@
+package com.jabiseo.learning.application.usecase;
+
+import com.jabiseo.certificate.domain.Certificate;
+import com.jabiseo.certificate.domain.CertificateRepository;
+import com.jabiseo.certificate.exception.CertificateBusinessException;
+import com.jabiseo.certificate.exception.CertificateErrorCode;
+import com.jabiseo.learning.domain.*;
+import com.jabiseo.learning.dto.CreateLearningRequest;
+import com.jabiseo.learning.dto.ProblemResultRequest;
+import com.jabiseo.member.domain.Member;
+import com.jabiseo.member.domain.MemberRepository;
+import com.jabiseo.problem.domain.Problem;
+import com.jabiseo.problem.domain.ProblemRepository;
+import com.jabiseo.problem.exception.ProblemBusinessException;
+import com.jabiseo.problem.exception.ProblemErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static fixture.CertificateFixture.createCertificate;
+import static fixture.LearningFixture.createLearning;
+import static fixture.MemberFixture.createMember;
+import static fixture.ProblemFixture.createProblem;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("결과 제출 (Learning 생성) 테스트")
+class CreateLearningUseCaseTest {
+
+    @InjectMocks
+    CreateLearningUseCase sut;
+
+    @Mock
+    MemberRepository memberRepository;
+
+    @Mock
+    CertificateRepository certificateRepository;
+
+    @Mock
+    ProblemRepository problemRepository;
+
+    @Mock
+    LearningRepository learningRepository;
+
+    @Mock
+    ProblemSolvingRepository problemSolvingRepository;
+
+    @Test
+    @DisplayName("존재하지 않는 자격증으로 학습 결과 제출 시 예외가 발생한다.")
+    void givenNonExistedCertificate_whenCreateLearning_thenThrowsException() {
+        //given
+        Long learningTime = 100L;
+        Long memberId = 1L;
+        Long certificateId = 2L;
+        Member member = createMember(memberId);
+        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+        CreateLearningRequest request = new CreateLearningRequest(learningTime, LearningMode.EXAM, certificateId, List.of());
+
+        //when & then
+        assertThatThrownBy(() -> sut.execute(memberId, request))
+                .isInstanceOf(CertificateBusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", CertificateErrorCode.CERTIFICATE_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 문제로 학습 결과 제출 시 예외가 발생한다.")
+    void givenNonExistedProblem_whenCreateLearning_thenThrowsException() {
+        //given
+        Long learningTime = 100L;
+        Long memberId = 1L;
+        Long certificateId = 2L;
+        List<Long> problemIds = List.of(3L, 4L);
+        Member member = createMember(memberId);
+        Certificate certificate = createCertificate(certificateId);
+        List<Problem> problems = problemIds.stream().map(problemId -> createProblem(problemId, certificate)).toList();
+        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+        given(certificateRepository.findById(certificateId)).willReturn(Optional.of(certificate));
+        given(problemRepository.findAllById(problemIds)).willReturn(List.of());
+
+        CreateLearningRequest request = new CreateLearningRequest(learningTime, LearningMode.EXAM, certificateId,
+                problems.stream().map(problem -> new ProblemResultRequest(problem.getId(), 1)).toList());
+
+        //when & then
+        assertThatThrownBy(() -> sut.execute(memberId, request))
+                .isInstanceOf(ProblemBusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ProblemErrorCode.PROBLEM_NOT_FOUND);
+    }
+
+
+    @Test
+    @DisplayName("자격증에 속하지 않는 문제로 학습 결과 제출 시 예외가 발생한다.")
+    void givenNotMatchedProblemId_whenCreateLearning_thenThrowsException() {
+        //given
+        Long learningTime = 100L;
+        Long memberId = 1L;
+        Long certificateId = 2L;
+        Long anotherCertificateId = 10L;
+        List<Long> problemIds = List.of(3L, 4L);
+
+        Member member = createMember(memberId);
+        Certificate certificate = createCertificate(anotherCertificateId);
+        Certificate anotherCertificate = createCertificate(anotherCertificateId);
+        List<Problem> problems = problemIds.stream().map(problemId -> createProblem(problemId, anotherCertificate)).toList();
+
+        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+        given(certificateRepository.findById(certificateId)).willReturn(Optional.of(certificate));
+        given(problemRepository.findAllById(problemIds)).willReturn(problems);
+
+        CreateLearningRequest request = new CreateLearningRequest(learningTime, LearningMode.EXAM, certificateId,
+                problems.stream().map(problem -> new ProblemResultRequest(problem.getId(), 1)).toList());
+
+        //when & then
+        assertThatThrownBy(() -> sut.execute(memberId, request))
+                .isInstanceOf(CertificateBusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", CertificateErrorCode.PROBLEM_NOT_FOUND_IN_CERTIFICATE);
+    }
+
+    @Test
+    @DisplayName("문제 풀이 결과가 주어지면 학습 결과 생성에 성공한다.")
+    void givenResultOfProblemSolving_whenCreateLearning_thenCreateLearning() {
+        //given
+        Long learningTime = 100L;
+        Long memberId = 1L;
+        Long certificateId = 2L;
+        List<Long> problemIds = List.of(3L, 4L);
+        Long learningId = 5L;
+
+        Member member = createMember(memberId);
+        Certificate certificate = createCertificate(certificateId);
+        List<Problem> problems = problemIds.stream().map(problemId -> createProblem(problemId, certificate)).toList();
+        Learning learning = createLearning(learningId, certificate);
+
+        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+        given(certificateRepository.findById(certificateId)).willReturn(Optional.of(certificate));
+        given(problemRepository.findAllById(problemIds)).willReturn(problems);
+        given(problemSolvingRepository.saveAll(any())).willReturn(List.of());
+        given(learningRepository.save(any())).willReturn(learning);
+
+        CreateLearningRequest request = new CreateLearningRequest(learningTime, LearningMode.EXAM, certificateId,
+                problems.stream().map(problem -> new ProblemResultRequest(problem.getId(), 1)).toList());
+
+        //when
+        sut.execute(memberId, request);
+
+        //then
+        ArgumentCaptor<Learning> learningCaptor = ArgumentCaptor.forClass(Learning.class);
+        verify(learningRepository).save(learningCaptor.capture());
+        Learning savedLearning = learningCaptor.getValue();
+        assertThat(savedLearning).isNotNull();
+
+        ArgumentCaptor<List<ProblemSolving>> problemSolvingCaptor = ArgumentCaptor.forClass(List.class);
+        verify(problemSolvingRepository).saveAll(problemSolvingCaptor.capture());
+        List<ProblemSolving> savedProblemSolvings = problemSolvingCaptor.getValue();
+        assertThat(savedProblemSolvings).isNotEmpty();
+    }
+
+}

--- a/jabiseo-api/src/test/java/com/jabiseo/learning/application/usecase/CreateLearningUseCaseTest.java
+++ b/jabiseo-api/src/test/java/com/jabiseo/learning/application/usecase/CreateLearningUseCaseTest.java
@@ -65,7 +65,7 @@ class CreateLearningUseCaseTest {
         Long certificateId = 2L;
         Member member = createMember(memberId);
         given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
-        CreateLearningRequest request = new CreateLearningRequest(learningTime, LearningMode.EXAM, certificateId, List.of());
+        CreateLearningRequest request = new CreateLearningRequest(learningTime, "EXAM", certificateId, List.of());
 
         //when & then
         assertThatThrownBy(() -> sut.execute(memberId, request))
@@ -88,7 +88,7 @@ class CreateLearningUseCaseTest {
         given(certificateRepository.findById(certificateId)).willReturn(Optional.of(certificate));
         given(problemRepository.findAllById(problemIds)).willReturn(List.of());
 
-        CreateLearningRequest request = new CreateLearningRequest(learningTime, LearningMode.EXAM, certificateId,
+        CreateLearningRequest request = new CreateLearningRequest(learningTime, "EXAM", certificateId,
                 problems.stream().map(problem -> new ProblemResultRequest(problem.getId(), 1)).toList());
 
         //when & then
@@ -117,7 +117,7 @@ class CreateLearningUseCaseTest {
         given(certificateRepository.findById(certificateId)).willReturn(Optional.of(certificate));
         given(problemRepository.findAllById(problemIds)).willReturn(problems);
 
-        CreateLearningRequest request = new CreateLearningRequest(learningTime, LearningMode.EXAM, certificateId,
+        CreateLearningRequest request = new CreateLearningRequest(learningTime, "EXAM", certificateId,
                 problems.stream().map(problem -> new ProblemResultRequest(problem.getId(), 1)).toList());
 
         //when & then
@@ -147,7 +147,7 @@ class CreateLearningUseCaseTest {
         given(problemSolvingRepository.saveAll(any())).willReturn(List.of());
         given(learningRepository.save(any())).willReturn(learning);
 
-        CreateLearningRequest request = new CreateLearningRequest(learningTime, LearningMode.EXAM, certificateId,
+        CreateLearningRequest request = new CreateLearningRequest(learningTime, "EXAM", certificateId,
                 problems.stream().map(problem -> new ProblemResultRequest(problem.getId(), 1)).toList());
 
         //when

--- a/jabiseo-api/src/test/java/com/jabiseo/learning/dto/CreateLearningRequestTest.java
+++ b/jabiseo-api/src/test/java/com/jabiseo/learning/dto/CreateLearningRequestTest.java
@@ -1,0 +1,130 @@
+package com.jabiseo.learning.dto;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("CreateLearning 입력값 검증 테스트")
+class CreateLearningRequestTest {
+
+    private Validator validator;
+
+    @BeforeEach
+    void init() {
+        ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory();
+        validator = validatorFactory.getValidator();
+    }
+
+    @DisplayName("CreateLearning 요청시 learningTime에 정확한 값이 오지 않으면 예외를 반환한다.")
+    @ParameterizedTest
+    @ValueSource(longs = {0L, -1L, -100L, 1000000001L})
+    void givenCreateLearningRequestWithWrongLearningTime_WhenCreateLearningDto_ThenReturnError(long learningTime) {
+        //given
+        List<ProblemResultRequest> problemResultRequests = List.of(new ProblemResultRequest(1L, 1));
+        CreateLearningRequest createLearningRequest = new CreateLearningRequest(learningTime, "EXAM", 1L, problemResultRequests);
+
+        //when
+        Set<ConstraintViolation<CreateLearningRequest>> violations = validator.validate(createLearningRequest);
+
+        //then
+        assertThat(violations).isNotEmpty();
+    }
+
+    @DisplayName("CreateLearning 요청시 learningMode에 정확한 값이 오지 않으면 예외를 반환한다.")
+    @ParameterizedTest
+    @ValueSource(strings = {"", " ", "WRONG", "exam"})
+    void givenCreateLearningRequestWithWrongLearningMode_WhenCreateLearningDto_ThenReturnError(String learningMode) {
+        //given
+        List<ProblemResultRequest> problemResultRequests = List.of(new ProblemResultRequest(1L, 1));
+        CreateLearningRequest createLearningRequest = new CreateLearningRequest(100L, learningMode, 1L, problemResultRequests);
+
+        //when
+        Set<ConstraintViolation<CreateLearningRequest>> violations = validator.validate(createLearningRequest);
+
+        //then
+        assertThat(violations).isNotEmpty();
+    }
+
+    @DisplayName("CreateLearning 요청시 certificateId에 정확한 값이 오지 않으면 예외를 반환한다.")
+    @Test
+    void givenCreateLearningRequestWithWrongCertificateId_WhenCreateLearningDto_ThenReturnError() {
+        //given
+        Long certificateId = null;
+        List<ProblemResultRequest> problemResultRequests = List.of(new ProblemResultRequest(1L, 1));
+        CreateLearningRequest createLearningRequest = new CreateLearningRequest(100L, "EXAM", certificateId, problemResultRequests);
+
+        //when
+        Set<ConstraintViolation<CreateLearningRequest>> violations = validator.validate(createLearningRequest);
+
+        //then
+        assertThat(violations).isNotEmpty();
+    }
+
+    @DisplayName("CreateLearning 요청시 problems가 비어 있으면 예외를 반환한다.")
+    @Test
+    void givenCreateLearningRequestWithWrongProblems_WhenCreateLearningDto_ThenReturnError() {
+        //given
+        List<ProblemResultRequest> problemResultRequests = List.of();
+        CreateLearningRequest createLearningRequest = new CreateLearningRequest(100L, "EXAM", 1L, problemResultRequests);
+
+        //when
+        Set<ConstraintViolation<CreateLearningRequest>> violations = validator.validate(createLearningRequest);
+
+        //then
+        assertThat(violations).isNotEmpty();
+    }
+
+    @DisplayName("ProblemResultRequest 생성시 problemId가 null이면 예외를 반환한다.")
+    @Test
+    void givenCreateLearningRequestWithNullProblemId_WhenCreateProblemResultRequest_ThenReturnError() {
+        //given
+        Long problemId = null;
+        ProblemResultRequest problemResultRequest = new ProblemResultRequest(problemId, 1);
+
+        //when
+        Set<ConstraintViolation<ProblemResultRequest>> violations = validator.validate(problemResultRequest);
+
+        //then
+        assertThat(violations).isNotEmpty();
+    }
+
+    @DisplayName("ProblemResultRequest 생성시 choice에 정확한 값이 오지 않으면 예외를 반환한다.")
+    @ParameterizedTest
+    @ValueSource(ints = {0, -1, 5, 100})
+    void givenCreateLearningRequestWithWrongChoice_WhenCreateProblemResultRequest_ThenReturnError(int choice) {
+        //given
+        ProblemResultRequest problemResultRequest = new ProblemResultRequest(1L, choice);
+
+        //when
+        Set<ConstraintViolation<ProblemResultRequest>> violations = validator.validate(problemResultRequest);
+
+        //then
+        assertThat(violations).isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("정상적인 입력 요청 시 성공한다.")
+    void givenValidRequest_whenCreateLearning_thenSuccess() {
+        //given
+        List<ProblemResultRequest> problemResultRequests = List.of(new ProblemResultRequest(1L, 1));
+        CreateLearningRequest createLearningRequest = new CreateLearningRequest(100L, "EXAM", 1L, problemResultRequests);
+
+        //when
+        Set<ConstraintViolation<CreateLearningRequest>> violations = validator.validate(createLearningRequest);
+
+        //then
+        assertThat(violations).isEmpty();
+    }
+
+}

--- a/jabiseo-domain/src/main/java/com/jabiseo/learning/domain/Learning.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/learning/domain/Learning.java
@@ -1,0 +1,47 @@
+package com.jabiseo.learning.domain;
+
+import com.jabiseo.certificate.domain.Certificate;
+import io.hypersistence.utils.hibernate.id.Tsid;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class Learning {
+
+    @Id
+    @Tsid
+    @Column(name = "learning-id")
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private LearningMode mode;
+
+    private Long learningTime;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "certificate-id", foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
+    private Certificate certificate;
+
+    private Learning(LearningMode mode, Long learningTime, Certificate certificate) {
+        this.mode = mode;
+        this.learningTime = learningTime;
+        this.certificate = certificate;
+    }
+
+    public static Learning of(LearningMode mode, Long learningTime, Certificate certificate) {
+        return new Learning(mode, learningTime, certificate);
+    }
+}

--- a/jabiseo-domain/src/main/java/com/jabiseo/learning/domain/LearningRepository.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/learning/domain/LearningRepository.java
@@ -1,0 +1,6 @@
+package com.jabiseo.learning.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LearningRepository extends JpaRepository<Learning, Long> {
+}

--- a/jabiseo-domain/src/main/java/com/jabiseo/learning/domain/ProblemSolving.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/learning/domain/ProblemSolving.java
@@ -1,0 +1,49 @@
+package com.jabiseo.learning.domain;
+
+import com.jabiseo.member.domain.Member;
+import com.jabiseo.problem.domain.Problem;
+import io.hypersistence.utils.hibernate.id.Tsid;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "problem_solving")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProblemSolving {
+
+    @Id
+    @Tsid
+    @Column(name = "problem_solving_id")
+    private Long id;
+
+    private int selectedChoice;
+
+    private boolean isCorrect;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "problem_id", foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
+    private Problem problem;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "learning_id", foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
+    private Learning learning;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
+    private Member member;
+
+    private ProblemSolving(Member member, Problem problem, Learning learning, int selectedChoice, boolean isCorrect) {
+        this.member = member;
+        this.problem = problem;
+        this.learning = learning;
+        this.selectedChoice = selectedChoice;
+        this.isCorrect = isCorrect;
+    }
+
+    public static ProblemSolving of(Member member, Problem problem, Learning learning, int selectedChoice, boolean isCorrect) {
+        return new ProblemSolving(member, problem, learning, selectedChoice, isCorrect);
+    }
+}

--- a/jabiseo-domain/src/main/java/com/jabiseo/learning/domain/ProblemSolvingRepository.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/learning/domain/ProblemSolvingRepository.java
@@ -1,0 +1,6 @@
+package com.jabiseo.learning.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProblemSolvingRepository extends JpaRepository<ProblemSolving, Long> {
+}

--- a/jabiseo-domain/src/main/java/com/jabiseo/problem/domain/Problem.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/problem/domain/Problem.java
@@ -79,4 +79,8 @@ public class Problem {
             throw new CertificateBusinessException(CertificateErrorCode.PROBLEM_NOT_FOUND_IN_CERTIFICATE);
         }
     }
+
+    public boolean checkAnswer(int choice) {
+        return this.answerNumber == choice;
+    }
 }

--- a/jabiseo-domain/src/main/java/com/jabiseo/problem/exception/ProblemErrorCode.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/problem/exception/ProblemErrorCode.java
@@ -10,6 +10,7 @@ public enum ProblemErrorCode implements ErrorCode {
     INVALID_PROBLEM_COUNT("문제의 개수가 올바르지 않습니다.", "PRB_002", ErrorCode.BAD_REQUEST),
     BOOKMARK_ALREADY_EXISTS("이미 북마크한 문제입니다.", "PRB_003", ErrorCode.BAD_REQUEST),
     BOOKMARK_NOT_FOUND("북마크 정보를 찾을 수 없습니다.", "PRB_004", ErrorCode.NOT_FOUND),
+    DUPLICATED_SOLVING_PROBLEM("문제를 중복해서 풀 수 없습니다.", "PRB_005", ErrorCode.BAD_REQUEST),
     ;
 
 

--- a/jabiseo-domain/src/test/java/com/jabiseo/problem/domain/ProblemTest.java
+++ b/jabiseo-domain/src/test/java/com/jabiseo/problem/domain/ProblemTest.java
@@ -6,10 +6,14 @@ import com.jabiseo.certificate.exception.CertificateErrorCode;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static fixture.CertificateFixture.createCertificate;
 import static fixture.ProblemFixture.createProblem;
+import static fixture.ProblemFixture.createProblemWithAnswer;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
@@ -47,5 +51,19 @@ class ProblemTest {
                 .hasFieldOrPropertyWithValue("errorCode", CertificateErrorCode.PROBLEM_NOT_FOUND_IN_CERTIFICATE);
     }
 
+    @ParameterizedTest
+    @DisplayName("문제를 채점한다.")
+    @CsvSource({"1, false", "2, false", "3, true", "4, false"})
+    void givenProblemAndChoice_whenCheckProblem_thenCheckAnswer(int choice, boolean checkResult) {
+        //given
+        Long certificateId = 1L;
+        Long problemId = 2L;
+
+        Certificate certificate = createCertificate(certificateId);
+        Problem problem = createProblemWithAnswer(problemId, 3, certificate);
+
+        //when & then
+        assertThat(problem.checkAnswer(choice)).isEqualTo(checkResult);
+    }
 
 }

--- a/jabiseo-domain/src/testFixtures/java/fixture/LearningFixture.java
+++ b/jabiseo-domain/src/testFixtures/java/fixture/LearningFixture.java
@@ -1,0 +1,16 @@
+package fixture;
+
+import com.jabiseo.certificate.domain.Certificate;
+import com.jabiseo.learning.domain.Learning;
+import com.jabiseo.learning.domain.LearningMode;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class LearningFixture {
+
+    public static Learning createLearning(Long id, Certificate certificate) {
+        Learning learning = Learning.of(LearningMode.EXAM, 123L, certificate);
+        ReflectionTestUtils.setField(learning, "id", id);
+        return learning;
+    }
+
+}

--- a/jabiseo-domain/src/testFixtures/java/fixture/ProblemFixture.java
+++ b/jabiseo-domain/src/testFixtures/java/fixture/ProblemFixture.java
@@ -37,6 +37,24 @@ public class ProblemFixture {
         return createProblem(id, createCertificate(1234L));
     }
 
+    public static Problem createProblemWithAnswer(Long id, int answer, Certificate certificate) {
+        Problem problem = Problem.of(
+                "problem description",
+                "choice1",
+                "choice2",
+                "choice3",
+                "choice4",
+                answer,
+                "problem theory",
+                1,
+                certificate,
+                ExamFixture.createExam(5432L, certificate),
+                createSubject(9876L, certificate)
+        );
+        ReflectionTestUtils.setField(problem, "id", id);
+        return problem;
+    }
+
     public static Problem createProblem(Certificate certificate, Exam exam, Subject subject) {
         return Problem.of(
                 "problem description",


### PR DESCRIPTION
## PR 변경된 내용
### Learning, ProblemSolving Entity 구현
- Learning과 ProblemSolving을 1대다 관계로 매핑
- Learning에서 ProblemSolving을 참조하지 않도록 했으며 추후 필요할 시 추가
- ProblemSolving Entity를 생성할 때 필요한 채점 결과를 위해 Problem Entity에 채점하는 메소드를 추가

### 결과 제출 API 구현
- API 명세에 맞춰 Request dto 변경
- Request dto에 Valid 어노테이션 활용 및 이 검증에 대한 테스트 코드 구현
  - EnumValid 어노테이션 활용해서 LearningMode 검증
- 푼 문제 리스트와 고른 선지가 다른 리스트에 저장됨. 이를 해결하기 위해 HashMap을 사용
```java
 // solvedProblems와 request의 choice들을 매핑하기 위해 HashMap 사용
Map<Long, Integer> problemIdToChoice = request.problems().stream()
        .collect(Collectors.toMap(
                ProblemResultRequest::problemId,
                ProblemResultRequest::choice
        ));
List<ProblemSolving> problemSolvings = solvedProblems.stream()
        .map(problem -> ProblemSolving.of(
                member,
                problem,
                learning,
                problemIdToChoice.get(problem.getId()),
                problem.checkAnswer(problemIdToChoice.get(problem.getId()))
        ))
        .toList();
```
- 중복된 문제를 풀었을 경우 예외처리
```java
if (request.problems().stream().distinct().count() != request.problems().size()) {
    throw new ProblemBusinessException(ProblemErrorCode.DUPLICATED_SOLVING_PROBLEM);
}
```

## 추가 내용
- 문제 id로 조회 시 중복된 id가 요청되면 중복 제거 후 응답 & 테스트 코드 추가
```java
List<Long> problemIds = request.problemIds()
        .stream()
        .distinct()
        .toList();
```

- 문제 세트 조회 시 중복된 subject id가 요청되면 중복 제거 후 응답 & 테스트 코드 추가
```java
List<ProblemWithBookmarkDetailQueryDto> problemWithBookmarkDetailQueryDtos = subjectIds.stream()
        .distinct()
        ...
```

## 참조
Closes #58 
