### PR TITLE
Feat(Problem): 문제 상세 조회 API, 유사 문제 조회 API 구현     

### DIFF
--- a/jabiseo-api/src/main/java/com/jabiseo/auth/controller/DevAuthController.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/auth/controller/DevAuthController.java
@@ -5,7 +5,6 @@ import com.jabiseo.auth.dto.LoginResponse;
 import com.jabiseo.common.exception.CommonErrorCode;
 import com.jabiseo.exception.ErrorResponse;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.env.Environment;
 import org.springframework.http.ResponseEntity;
@@ -23,7 +22,9 @@ public class DevAuthController {
     private static final String LIMIT_PROFILE = "local";
 
     @GetMapping("/dev/auth")
-    public ResponseEntity<?> devAuth(@RequestParam(value = "member-id") @NotBlank String memberId) {
+    public ResponseEntity<?> devAuth(
+            @RequestParam(value = "member-id") @NotBlank String memberId
+    ) {
         if (!isLocalProfiles(environment.getActiveProfiles())) {
             return ResponseEntity.status(CommonErrorCode.FORBIDDEN.getStatusCode()).body(ErrorResponse.of(CommonErrorCode.FORBIDDEN));
         }

--- a/jabiseo-api/src/main/java/com/jabiseo/common/security/SecurityConfig.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/common/security/SecurityConfig.java
@@ -9,9 +9,14 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.util.matcher.RegexRequestMatcher;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Arrays;
 
 @Configuration
 @RequiredArgsConstructor
+@Transactional
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
@@ -24,6 +29,10 @@ public class SecurityConfig {
             "/api/problems/set",
             "/api/problems/search/**",
             "/api/dev/auth",
+    };
+
+    private static final String[] REGEX_WHITE_LIST = {
+            "/api/problems/\\d+"
     };
 
     @Bean
@@ -39,6 +48,11 @@ public class SecurityConfig {
                 )
                 .authorizeHttpRequests((authorize) -> authorize
                         .requestMatchers(WHITE_LIST).permitAll()
+                        .requestMatchers(
+                                Arrays.stream(REGEX_WHITE_LIST)
+                                        .map(RegexRequestMatcher::regexMatcher)
+                                        .toArray(RegexRequestMatcher[]::new)
+                        ).permitAll()
                         .requestMatchers("/**").authenticated()
                 );
 

--- a/jabiseo-api/src/main/java/com/jabiseo/exception/GlobalExceptionHandler.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/exception/GlobalExceptionHandler.java
@@ -74,14 +74,13 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<?> handleException(Exception e) {
-        StringBuilder errorMessage = new StringBuilder();
         log.error(e.getMessage());
-        errorMessage.append(e.getMessage())
-                .append(" ")
-                .append(CommonErrorCode.INTERNAL_SERVER_ERROR.getMessage());
+        String errorMessage = e.getMessage() +
+                              " " +
+                              CommonErrorCode.INTERNAL_SERVER_ERROR.getMessage();
         return ResponseEntity
                 .status(ErrorCode.INTERNAL_SERVER_ERROR)
-                .body(new ErrorResponse(errorMessage.toString(), CommonErrorCode.INTERNAL_SERVER_ERROR.getErrorCode()));
+                .body(new ErrorResponse(errorMessage, CommonErrorCode.INTERNAL_SERVER_ERROR.getErrorCode()));
     }
 
 }

--- a/jabiseo-api/src/main/java/com/jabiseo/exception/GlobalExceptionHandler.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/exception/GlobalExceptionHandler.java
@@ -4,7 +4,6 @@ import com.jabiseo.common.exception.BusinessException;
 import com.jabiseo.common.exception.CommonErrorCode;
 import com.jabiseo.common.exception.ErrorCode;
 import com.jabiseo.database.exception.PersistenceException;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -14,7 +13,6 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.HandlerMethodValidationException;
 @Slf4j
 @RestControllerAdvice
-@RequiredArgsConstructor
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(BusinessException.class)

--- a/jabiseo-api/src/main/java/com/jabiseo/exception/GlobalExceptionHandler.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/exception/GlobalExceptionHandler.java
@@ -12,7 +12,6 @@ import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.HandlerMethodValidationException;
-
 @Slf4j
 @RestControllerAdvice
 @RequiredArgsConstructor
@@ -20,6 +19,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(BusinessException.class)
     public ResponseEntity<?> handleBusinessException(BusinessException e) {
+        log.info(e.getMessage());
         ErrorCode code = e.getErrorCode();
         return ResponseEntity
                 .status(code.getStatusCode())
@@ -28,6 +28,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(PersistenceException.class)
     public ResponseEntity<?> handlePersistenceException(PersistenceException e) {
+        log.info(e.getMessage());
         ErrorCode code = e.getErrorCode();
         return ResponseEntity
                 .status(code.getStatusCode())
@@ -60,8 +61,8 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<?> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        log.info(e.getMessage());
         ErrorCode errorCode = CommonErrorCode.INVALID_REQUEST_BODY;
-        log.error(e.getMessage());
         StringBuilder errors = new StringBuilder();
         e.getBindingResult()
                 .getFieldErrors()

--- a/jabiseo-api/src/main/java/com/jabiseo/exception/GlobalExceptionHandler.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/exception/GlobalExceptionHandler.java
@@ -60,7 +60,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<?> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
-        ErrorCode errorCode = CommonErrorCode.INVALID_REQUEST_PARAMETER;
+        ErrorCode errorCode = CommonErrorCode.INVALID_REQUEST_BODY;
         log.error(e.getMessage());
         StringBuilder errors = new StringBuilder();
         e.getBindingResult()

--- a/jabiseo-api/src/main/java/com/jabiseo/learning/dto/ProblemResultRequest.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/learning/dto/ProblemResultRequest.java
@@ -8,8 +8,8 @@ public record ProblemResultRequest(
         @NotNull(message = "문제 ID를 입력해야 합니다.")
         Long problemId,
 
-        @Min(value = 1L, message = "선지는 1번부터 4번까지 존재합니다.")
-        @Max(value = 4L, message = "선지는 1번부터 4번까지 존재합니다.")
+        @Min(value = 0L, message = "선지는 1번부터 4번까지 존재합니다. 만약 풀지 않은 문제라면 0을 입력해주세요.")
+        @Max(value = 4L, message = "선지는 1번부터 4번까지 존재합니다. 만약 풀지 않은 문제라면 0을 입력해주세요.")
         int choice
 ) {
 }

--- a/jabiseo-api/src/main/java/com/jabiseo/learning/dto/ProblemResultRequest.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/learning/dto/ProblemResultRequest.java
@@ -8,8 +8,8 @@ public record ProblemResultRequest(
         @NotNull(message = "문제 ID를 입력해야 합니다.")
         Long problemId,
 
-        @Min(value = 0L, message = "선지는 1번부터 4번까지 존재합니다. 만약 풀지 않은 문제라면 0을 입력해주세요.")
-        @Max(value = 4L, message = "선지는 1번부터 4번까지 존재합니다. 만약 풀지 않은 문제라면 0을 입력해주세요.")
+        @Min(value = 1L, message = "선지는 1번부터 4번까지 존재합니다.")
+        @Max(value = 4L, message = "선지는 1번부터 4번까지 존재합니다.")
         int choice
 ) {
 }

--- a/jabiseo-api/src/main/java/com/jabiseo/problem/application/usecase/FindProblemDetailUseCase.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/problem/application/usecase/FindProblemDetailUseCase.java
@@ -2,6 +2,7 @@ package com.jabiseo.problem.application.usecase;
 
 import com.jabiseo.problem.domain.ProblemRepository;
 import com.jabiseo.problem.dto.FindProblemDetailResponse;
+import com.jabiseo.problem.dto.ProblemWithBookmarkDetailQueryDto;
 import com.jabiseo.problem.dto.ProblemsDetailResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,8 +16,9 @@ public class FindProblemDetailUseCase {
     private final ProblemRepository problemRepository;
 
     public FindProblemDetailResponse execute(Long memberId, Long problemId) {
-        ProblemsDetailResponse problemDetailResponse =
-                ProblemsDetailResponse.from(problemRepository.findDetailByIdWithBookmark(memberId, problemId));
+
+        ProblemWithBookmarkDetailQueryDto dto = problemRepository.findDetailByIdWithBookmark(memberId, problemId);
+        ProblemsDetailResponse problemDetailResponse = ProblemsDetailResponse.from(dto);
 
         return FindProblemDetailResponse.of(problemDetailResponse);
     }

--- a/jabiseo-api/src/main/java/com/jabiseo/problem/application/usecase/FindProblemDetailUseCase.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/problem/application/usecase/FindProblemDetailUseCase.java
@@ -1,0 +1,23 @@
+package com.jabiseo.problem.application.usecase;
+
+import com.jabiseo.problem.domain.ProblemRepository;
+import com.jabiseo.problem.dto.FindProblemDetailResponse;
+import com.jabiseo.problem.dto.ProblemsDetailResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class FindProblemDetailUseCase {
+
+    private final ProblemRepository problemRepository;
+
+    public FindProblemDetailResponse execute(Long memberId, Long problemId) {
+        ProblemsDetailResponse problemDetailResponse =
+                ProblemsDetailResponse.from(problemRepository.findDetailByIdWithBookmark(memberId, problemId));
+
+        return FindProblemDetailResponse.of(problemDetailResponse);
+    }
+}

--- a/jabiseo-api/src/main/java/com/jabiseo/problem/application/usecase/FindSimilarProblemsUseCase.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/problem/application/usecase/FindSimilarProblemsUseCase.java
@@ -1,0 +1,33 @@
+package com.jabiseo.problem.application.usecase;
+
+import com.jabiseo.opensearch.SimilarProblemsProvider;
+import com.jabiseo.problem.domain.ProblemRepository;
+import com.jabiseo.problem.dto.FindSimilarProblemResponse;
+import com.jabiseo.problem.dto.ProblemWithBookmarkSummaryQueryDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class FindSimilarProblemsUseCase {
+
+    private static final int SIMILAR_PROBLEM_SIZE = 3;
+
+    private final ProblemRepository problemRepository;
+
+    private final SimilarProblemsProvider similarProblemsProvider;
+
+    public List<FindSimilarProblemResponse> execute(Long memberId, Long problemId) {
+
+        List<Long> similarProblemIds = similarProblemsProvider.getSimilarProblems(problemId, SIMILAR_PROBLEM_SIZE);
+        List<ProblemWithBookmarkSummaryQueryDto> dtos = problemRepository.findSummaryByIdsInWithBookmark(memberId, similarProblemIds);
+
+        return dtos.stream()
+                .map(FindSimilarProblemResponse::of)
+                .toList();
+    }
+}

--- a/jabiseo-api/src/main/java/com/jabiseo/problem/application/usecase/FindSimilarProblemsUseCase.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/problem/application/usecase/FindSimilarProblemsUseCase.java
@@ -1,9 +1,12 @@
 package com.jabiseo.problem.application.usecase;
 
 import com.jabiseo.opensearch.SimilarProblemsProvider;
+import com.jabiseo.problem.domain.Problem;
 import com.jabiseo.problem.domain.ProblemRepository;
 import com.jabiseo.problem.dto.FindSimilarProblemResponse;
 import com.jabiseo.problem.dto.ProblemWithBookmarkSummaryQueryDto;
+import com.jabiseo.problem.exception.ProblemBusinessException;
+import com.jabiseo.problem.exception.ProblemErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,7 +26,11 @@ public class FindSimilarProblemsUseCase {
 
     public List<FindSimilarProblemResponse> execute(Long memberId, Long problemId) {
 
-        List<Long> similarProblemIds = similarProblemsProvider.getSimilarProblems(problemId, SIMILAR_PROBLEM_SIZE);
+        Problem problem = problemRepository.findById(problemId)
+                .orElseThrow(() -> new ProblemBusinessException(ProblemErrorCode.PROBLEM_NOT_FOUND));
+        Long certificateId = problem.getCertificate().getId();
+
+        List<Long> similarProblemIds = similarProblemsProvider.getSimilarProblems(problemId, certificateId, SIMILAR_PROBLEM_SIZE);
         List<ProblemWithBookmarkSummaryQueryDto> dtos = problemRepository.findSummaryByIdsInWithBookmark(memberId, similarProblemIds);
 
         return dtos.stream()

--- a/jabiseo-api/src/main/java/com/jabiseo/problem/controller/ProblemController.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/problem/controller/ProblemController.java
@@ -2,14 +2,8 @@ package com.jabiseo.problem.controller;
 
 import com.jabiseo.config.auth.AuthMember;
 import com.jabiseo.config.auth.AuthenticatedMember;
-import com.jabiseo.problem.application.usecase.CreateReportUseCase;
-import com.jabiseo.problem.application.usecase.FindBookmarkedProblemsUseCase;
-import com.jabiseo.problem.application.usecase.FindProblemsByIdUseCase;
-import com.jabiseo.problem.application.usecase.FindProblemsUseCase;
-import com.jabiseo.problem.dto.CreateReportRequest;
-import com.jabiseo.problem.dto.FindBookmarkedProblemsResponse;
-import com.jabiseo.problem.dto.FindProblemsRequest;
-import com.jabiseo.problem.dto.FindProblemsResponse;
+import com.jabiseo.problem.application.usecase.*;
+import com.jabiseo.problem.dto.*;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
@@ -33,10 +27,13 @@ public class ProblemController {
 
     private final FindBookmarkedProblemsUseCase findBookmarkedProblemsUseCase;
 
+    private final FindProblemDetailUseCase findProblemDetailUseCase;
+
+//    private final FindSimilarProblemsUseCase findSimilarProblemsUseCase;
+
     @GetMapping("/set")
     public ResponseEntity<FindProblemsResponse> findProblems(
             @AuthenticatedMember AuthMember member,
-            // TODO: Valid에 대한 테스트
             @RequestParam(name = "certificate-id") Long certificateId,
             @RequestParam(name = "exam-id", required = false) Long examId,
             @RequestParam(name = "subject-id") List<Long> subjectIds,
@@ -84,4 +81,22 @@ public class ProblemController {
         FindBookmarkedProblemsResponse result = findBookmarkedProblemsUseCase.execute(member.getMemberId(), examId, subjectIds, page);
         return ResponseEntity.ok(result);
     }
+
+    @GetMapping("/{problem-id}")
+    public ResponseEntity<FindProblemDetailResponse> findProblemDetail(
+            @AuthenticatedMember AuthMember member,
+            @PathVariable(name = "problem-id") Long problemId
+    ) {
+        FindProblemDetailResponse result = findProblemDetailUseCase.execute(member.getMemberId(), problemId);
+        return ResponseEntity.ok(result);
+    }
+
+//    @GetMapping("/{problem-id}/similar")
+//    public ResponseEntity<List<FindSimilarProblemResponse>> findSimilarProblems(
+//            @AuthenticatedMember AuthMember member,
+//            @PathVariable(name = "problem-id") Long problemId
+//    ) {
+//        List<FindSimilarProblemResponse> result = findSimilarProblemsUseCase.execute(member.getMemberId(), problemId);
+//        return ResponseEntity.ok(result);
+//    }
 }

--- a/jabiseo-api/src/main/java/com/jabiseo/problem/controller/ProblemController.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/problem/controller/ProblemController.java
@@ -29,7 +29,7 @@ public class ProblemController {
 
     private final FindProblemDetailUseCase findProblemDetailUseCase;
 
-//    private final FindSimilarProblemsUseCase findSimilarProblemsUseCase;
+    private final FindSimilarProblemsUseCase findSimilarProblemsUseCase;
 
     @GetMapping("/set")
     public ResponseEntity<FindProblemsResponse> findProblems(
@@ -91,12 +91,12 @@ public class ProblemController {
         return ResponseEntity.ok(result);
     }
 
-//    @GetMapping("/{problem-id}/similar")
-//    public ResponseEntity<List<FindSimilarProblemResponse>> findSimilarProblems(
-//            @AuthenticatedMember AuthMember member,
-//            @PathVariable(name = "problem-id") Long problemId
-//    ) {
-//        List<FindSimilarProblemResponse> result = findSimilarProblemsUseCase.execute(member.getMemberId(), problemId);
-//        return ResponseEntity.ok(result);
-//    }
+    @GetMapping("/{problem-id}/similar")
+    public ResponseEntity<List<FindSimilarProblemResponse>> findSimilarProblems(
+            @AuthenticatedMember AuthMember member,
+            @PathVariable(name = "problem-id") Long problemId
+    ) {
+        List<FindSimilarProblemResponse> result = findSimilarProblemsUseCase.execute(member.getMemberId(), problemId);
+        return ResponseEntity.ok(result);
+    }
 }

--- a/jabiseo-api/src/main/java/com/jabiseo/problem/dto/FindBookmarkedProblemsResponse.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/problem/dto/FindBookmarkedProblemsResponse.java
@@ -5,7 +5,7 @@ import java.util.List;
 public record FindBookmarkedProblemsResponse(
         long totalCount,
         long totalPage,
-        List<ProblemsResponse> problems
+        List<ProblemsSummaryResponse> problems
 ) {
 
     public static FindBookmarkedProblemsResponse of(long totalCount, long totalPage, List<ProblemWithBookmarkSummaryQueryDto> dtos) {
@@ -13,7 +13,7 @@ public record FindBookmarkedProblemsResponse(
                 totalCount,
                 totalPage,
                 dtos.stream()
-                        .map(ProblemsResponse::from)
+                        .map(ProblemsSummaryResponse::from)
                         .toList()
         );
     }

--- a/jabiseo-api/src/main/java/com/jabiseo/problem/dto/FindProblemDetailResponse.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/problem/dto/FindProblemDetailResponse.java
@@ -1,0 +1,30 @@
+package com.jabiseo.problem.dto;
+
+import com.jabiseo.certificate.dto.ExamResponse;
+import com.jabiseo.certificate.dto.SubjectResponse;
+
+import java.util.List;
+
+public record FindProblemDetailResponse(
+        Long problemId,
+        ExamResponse examInfo,
+        SubjectResponse subjectInfo,
+        boolean isBookmark,
+        String description,
+        List<ChoiceResponse> choices,
+        int answerNumber,
+        String solution
+) {
+    public static FindProblemDetailResponse of(ProblemsDetailResponse problemsDetailResponse) {
+        return new FindProblemDetailResponse(
+                problemsDetailResponse.problemId(),
+                problemsDetailResponse.examInfo(),
+                problemsDetailResponse.subjectInfo(),
+                problemsDetailResponse.isBookmark(),
+                problemsDetailResponse.description(),
+                problemsDetailResponse.choices(),
+                problemsDetailResponse.answerNumber(),
+                problemsDetailResponse.solution()
+        );
+    }
+}

--- a/jabiseo-api/src/main/java/com/jabiseo/problem/dto/FindSimilarProblemResponse.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/problem/dto/FindSimilarProblemResponse.java
@@ -1,0 +1,22 @@
+package com.jabiseo.problem.dto;
+
+import com.jabiseo.certificate.dto.ExamResponse;
+import com.jabiseo.certificate.dto.SubjectResponse;
+
+public record FindSimilarProblemResponse(
+        Long problemId,
+        ExamResponse examInfo,
+        SubjectResponse subjectInfo,
+        boolean isBookmark,
+        String description
+) {
+    public static FindSimilarProblemResponse of(ProblemWithBookmarkSummaryQueryDto dto) {
+        return new FindSimilarProblemResponse(
+                dto.problemId(),
+                ExamResponse.of(dto.examId(), dto.examDescription()),
+                SubjectResponse.of(dto.subjectId(), dto.subjectSequence(), dto.subjectName()),
+                dto.isBookmark(),
+                dto.description()
+        );
+    }
+}

--- a/jabiseo-api/src/main/java/com/jabiseo/problem/dto/ProblemsSummaryResponse.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/problem/dto/ProblemsSummaryResponse.java
@@ -10,7 +10,6 @@ public record ProblemsSummaryResponse(
         boolean isBookmark,
         String description
 ) {
-
     public static ProblemsSummaryResponse from(ProblemWithBookmarkSummaryQueryDto dto) {
         return new ProblemsSummaryResponse(
                 dto.problemId(),

--- a/jabiseo-api/src/main/java/com/jabiseo/problem/dto/ProblemsSummaryResponse.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/problem/dto/ProblemsSummaryResponse.java
@@ -3,7 +3,7 @@ package com.jabiseo.problem.dto;
 import com.jabiseo.certificate.dto.ExamResponse;
 import com.jabiseo.certificate.dto.SubjectResponse;
 
-public record ProblemsResponse(
+public record ProblemsSummaryResponse(
         Long problemId,
         ExamResponse examInfo,
         SubjectResponse subjectInfo,
@@ -11,8 +11,8 @@ public record ProblemsResponse(
         String description
 ) {
 
-    public static ProblemsResponse from(ProblemWithBookmarkSummaryQueryDto dto) {
-        return new ProblemsResponse(
+    public static ProblemsSummaryResponse from(ProblemWithBookmarkSummaryQueryDto dto) {
+        return new ProblemsSummaryResponse(
                 dto.problemId(),
                 ExamResponse.of(dto.examId(), dto.examDescription()),
                 SubjectResponse.of(dto.subjectId(), dto.subjectSequence(), dto.subjectName()),

--- a/jabiseo-api/src/test/java/com/jabiseo/learning/dto/CreateLearningRequestTest.java
+++ b/jabiseo-api/src/test/java/com/jabiseo/learning/dto/CreateLearningRequestTest.java
@@ -101,7 +101,7 @@ class CreateLearningRequestTest {
 
     @DisplayName("ProblemResultRequest 생성시 choice에 정확한 값이 오지 않으면 예외를 반환한다.")
     @ParameterizedTest
-    @ValueSource(ints = {0, -1, 5, 100})
+    @ValueSource(ints = {-1, 5, 100})
     void givenCreateLearningRequestWithWrongChoice_WhenCreateProblemResultRequest_ThenReturnError(int choice) {
         //given
         ProblemResultRequest problemResultRequest = new ProblemResultRequest(1L, choice);

--- a/jabiseo-api/src/test/java/com/jabiseo/problem/application/usecase/FindBookmarkedProblemsUseCaseTest.java
+++ b/jabiseo-api/src/test/java/com/jabiseo/problem/application/usecase/FindBookmarkedProblemsUseCaseTest.java
@@ -9,7 +9,7 @@ import com.jabiseo.problem.domain.Problem;
 import com.jabiseo.problem.domain.ProblemRepository;
 import com.jabiseo.problem.dto.FindBookmarkedProblemsResponse;
 import com.jabiseo.problem.dto.ProblemWithBookmarkSummaryQueryDto;
-import com.jabiseo.problem.dto.ProblemsResponse;
+import com.jabiseo.problem.dto.ProblemsSummaryResponse;
 import fixture.ProblemFixture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -75,8 +75,8 @@ class FindBookmarkedProblemsUseCaseTest {
         //then
         assertThat(results.totalCount()).isEqualTo(2);
         assertThat(results.totalPage()).isEqualTo(1);
-        assertThat(results.problems().get(0)).isEqualTo(ProblemsResponse.from(dtos.get(0)));
-        assertThat(results.problems().get(1)).isEqualTo(ProblemsResponse.from(dtos.get(1)));
+        assertThat(results.problems().get(0)).isEqualTo(ProblemsSummaryResponse.from(dtos.get(0)));
+        assertThat(results.problems().get(1)).isEqualTo(ProblemsSummaryResponse.from(dtos.get(1)));
     }
 
     @Test
@@ -107,8 +107,8 @@ class FindBookmarkedProblemsUseCaseTest {
         //then
         assertThat(results.totalCount()).isEqualTo(2);
         assertThat(results.totalPage()).isEqualTo(1);
-        assertThat(results.problems().get(0)).isEqualTo(ProblemsResponse.from(dtos.get(0)));
-        assertThat(results.problems().get(1)).isEqualTo(ProblemsResponse.from(dtos.get(1)));
+        assertThat(results.problems().get(0)).isEqualTo(ProblemsSummaryResponse.from(dtos.get(0)));
+        assertThat(results.problems().get(1)).isEqualTo(ProblemsSummaryResponse.from(dtos.get(1)));
     }
 
     @Test

--- a/jabiseo-api/src/test/java/com/jabiseo/problem/application/usecase/FindProblemDetailUseCaseTest.java
+++ b/jabiseo-api/src/test/java/com/jabiseo/problem/application/usecase/FindProblemDetailUseCaseTest.java
@@ -1,0 +1,49 @@
+package com.jabiseo.problem.application.usecase;
+
+import com.jabiseo.problem.domain.ProblemRepository;
+import com.jabiseo.problem.dto.FindProblemDetailResponse;
+import com.jabiseo.problem.dto.ProblemWithBookmarkDetailQueryDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@DisplayName("문제 상세 조회 테스트")
+@ExtendWith(MockitoExtension.class)
+class FindProblemDetailUseCaseTest {
+    
+    @InjectMocks
+    FindProblemDetailUseCase sut;
+
+    @Mock
+    ProblemRepository problemRepository;
+
+    @Test
+    @DisplayName("문제 상세 조회를 성공한다.")
+    void givenMemberIdAndProblemId_whenFindingProblemDetail_thenFindProblemDetail() throws Exception {
+        //given
+        Long memberId = 1L;
+        Long problemId = 2L;
+        Long examId = 3L;
+        Long subjectId = 4L;
+        ProblemWithBookmarkDetailQueryDto problemWithBookmarkDetailQueryDto = new ProblemWithBookmarkDetailQueryDto(
+            problemId, "문제", "선지1", "선지2", "선지3", "선지4", 1, "해설", false, examId, "설명", subjectId, "이름", 1
+        );
+
+        given(problemRepository.findDetailByIdWithBookmark(memberId, problemId)).willReturn(problemWithBookmarkDetailQueryDto);
+
+        //when
+        FindProblemDetailResponse result = sut.execute(memberId, problemId);
+
+        //then
+        assertThat(result.problemId()).isEqualTo(problemId);
+        assertThat(result.examInfo().examId()).isEqualTo(examId);
+        assertThat(result.subjectInfo().subjectId()).isEqualTo(subjectId);
+    }
+
+}

--- a/jabiseo-api/src/test/java/com/jabiseo/problem/application/usecase/FindSimilarProblemsUseCaseTest.java
+++ b/jabiseo-api/src/test/java/com/jabiseo/problem/application/usecase/FindSimilarProblemsUseCaseTest.java
@@ -1,0 +1,61 @@
+package com.jabiseo.problem.application.usecase;
+
+import com.jabiseo.opensearch.SimilarProblemsProvider;
+import com.jabiseo.problem.domain.ProblemRepository;
+import com.jabiseo.problem.dto.FindSimilarProblemResponse;
+import com.jabiseo.problem.dto.ProblemWithBookmarkSummaryQueryDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@DisplayName("유사 문제 조회 테스트")
+@ExtendWith(MockitoExtension.class)
+class FindSimilarProblemsUseCaseTest {
+
+    @InjectMocks
+    FindSimilarProblemsUseCase sut;
+
+    @Mock
+    ProblemRepository problemRepository;
+
+    @Mock
+    SimilarProblemsProvider similarProblemsProvider;
+
+    @Test
+    @DisplayName("유사 문제 조회를 성공한다.")
+    void givenMemberIdAndProblemId_whenFindingSimilarProblems_thenFindSimilarProblems() throws Exception {
+        //given
+        Long memberId = 1L;
+        Long problemId = 2L;
+        Long examId = 3L;
+        Long subjectId = 4L;
+        List<Long> similarProblemIds = List.of(5L, 6L, 7L);
+        List<ProblemWithBookmarkSummaryQueryDto> problemWithBookmarkSummaryQueryDtos =
+                similarProblemIds.stream()
+                    .map(id -> new ProblemWithBookmarkSummaryQueryDto(
+                        id, "문제", false, examId, "설명", subjectId, "이름", 1
+                    ))
+                    .toList();
+
+        given(similarProblemsProvider.getSimilarProblems(problemId, 3)).willReturn(similarProblemIds);
+        given(problemRepository.findSummaryByIdsInWithBookmark(memberId, similarProblemIds)).willReturn(problemWithBookmarkSummaryQueryDtos);
+
+        //when
+        List<FindSimilarProblemResponse> result = sut.execute(memberId, problemId);
+
+        //then
+        assertThat(result).hasSize(3);
+        assertThat(result.get(0).problemId()).isEqualTo(5L);
+        assertThat(result.get(1).problemId()).isEqualTo(6L);
+        assertThat(result.get(2).problemId()).isEqualTo(7L);
+    }
+
+}

--- a/jabiseo-api/src/test/java/com/jabiseo/problem/application/usecase/FindSimilarProblemsUseCaseTest.java
+++ b/jabiseo-api/src/test/java/com/jabiseo/problem/application/usecase/FindSimilarProblemsUseCaseTest.java
@@ -1,6 +1,8 @@
 package com.jabiseo.problem.application.usecase;
 
+import com.jabiseo.certificate.domain.Certificate;
 import com.jabiseo.opensearch.SimilarProblemsProvider;
+import com.jabiseo.problem.domain.Problem;
 import com.jabiseo.problem.domain.ProblemRepository;
 import com.jabiseo.problem.dto.FindSimilarProblemResponse;
 import com.jabiseo.problem.dto.ProblemWithBookmarkSummaryQueryDto;
@@ -12,7 +14,10 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
+import java.util.Optional;
 
+import static fixture.CertificateFixture.createCertificate;
+import static fixture.ProblemFixture.createProblem;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 
@@ -31,21 +36,26 @@ class FindSimilarProblemsUseCaseTest {
 
     @Test
     @DisplayName("유사 문제 조회를 성공한다.")
-    void givenMemberIdAndProblemId_whenFindingSimilarProblems_thenFindSimilarProblems() throws Exception {
+    void givenMemberIdAndProblemId_whenFindingSimilarProblems_thenFindSimilarProblems() {
         //given
         Long memberId = 1L;
         Long problemId = 2L;
         Long examId = 3L;
         Long subjectId = 4L;
+        Long certificateId = 5L;
         List<Long> similarProblemIds = List.of(5L, 6L, 7L);
+
+        Certificate certificate = createCertificate(certificateId);
+        Problem problem = createProblem(problemId, certificate);
         List<ProblemWithBookmarkSummaryQueryDto> problemWithBookmarkSummaryQueryDtos =
                 similarProblemIds.stream()
-                    .map(id -> new ProblemWithBookmarkSummaryQueryDto(
-                        id, "문제", false, examId, "설명", subjectId, "이름", 1
-                    ))
-                    .toList();
+                        .map(id -> new ProblemWithBookmarkSummaryQueryDto(
+                                id, "문제", false, examId, "설명", subjectId, "이름", 1
+                        ))
+                        .toList();
 
-        given(similarProblemsProvider.getSimilarProblems(problemId, 3)).willReturn(similarProblemIds);
+        given(similarProblemsProvider.getSimilarProblems(problemId, certificateId, 3)).willReturn(similarProblemIds);
+        given(problemRepository.findById(problemId)).willReturn(Optional.of(problem));
         given(problemRepository.findSummaryByIdsInWithBookmark(memberId, similarProblemIds)).willReturn(problemWithBookmarkSummaryQueryDtos);
 
         //when

--- a/jabiseo-domain/src/main/java/com/jabiseo/problem/domain/querydsl/ProblemRepositoryCustom.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/problem/domain/querydsl/ProblemRepositoryCustom.java
@@ -13,5 +13,9 @@ public interface ProblemRepositoryCustom {
 
     List<ProblemWithBookmarkDetailQueryDto> findDetailByIdsInWithBookmark(Long memberId, List<Long> problemIds);
 
+    ProblemWithBookmarkDetailQueryDto findDetailByIdWithBookmark(Long memberId, Long problemId);
+
     Page<ProblemWithBookmarkSummaryQueryDto> findBookmarkedSummaryByExamIdAndSubjectIdsInWithBookmark(Long memberId, Long examId, List<Long> subjectIds, Pageable pageable);
+
+    List<ProblemWithBookmarkSummaryQueryDto> findSummaryByIdsInWithBookmark(Long memberId, List<Long> problemIds);
 }

--- a/jabiseo-infrastructure/build.gradle
+++ b/jabiseo-infrastructure/build.gradle
@@ -13,6 +13,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'io.awspring.cloud:spring-cloud-aws-s3:3.1.0'
 
+    implementation 'org.opensearch.client:opensearch-java:2.6.0'
+    implementation 'org.apache.httpcomponents.client5:httpclient5:5.1'
+    implementation 'org.apache.httpcomponents.core5:httpcore5:5.1'
 
     runtimeOnly 'com.mysql:mysql-connector-j'
 

--- a/jabiseo-infrastructure/src/main/java/com/jabiseo/client/NetworkApiErrorCode.java
+++ b/jabiseo-infrastructure/src/main/java/com/jabiseo/client/NetworkApiErrorCode.java
@@ -9,7 +9,10 @@ public enum NetworkApiErrorCode implements ErrorCode {
     KAKAO_JWK_API_FAIL("카카오 kauth jwk 연결 실패", "NETWORK_002", ErrorCode.INTERNAL_SERVER_ERROR),
     GOOGLE_OPENAI_CONFIG_API_FAIL("구글 openai 연결 실패", "NETWORK_003", ErrorCode.INTERNAL_SERVER_ERROR),
     GOOGLE_JWK_API_FAIL("구글 jwk 연결 실패", "NETWORK_004", ErrorCode.INTERNAL_SERVER_ERROR),
-    S3_UPLOAD_FAIL("s3 upload 실패", "NETWORK_005", ErrorCode.INTERNAL_SERVER_ERROR);
+    S3_UPLOAD_FAIL("s3 upload 실패", "NETWORK_005", ErrorCode.INTERNAL_SERVER_ERROR),
+    OPENSEARCH_API_FAIL("opensearch 연결 실패", "NETWORK_006", ErrorCode.INTERNAL_SERVER_ERROR),
+    ;
+
     private final String message;
     private final String errorCode;
     private final int statusCode;

--- a/jabiseo-infrastructure/src/main/java/com/jabiseo/opensearch/CertificateIndex.java
+++ b/jabiseo-infrastructure/src/main/java/com/jabiseo/opensearch/CertificateIndex.java
@@ -1,0 +1,31 @@
+package com.jabiseo.opensearch;
+
+import com.jabiseo.certificate.exception.CertificateBusinessException;
+import com.jabiseo.common.exception.CommonErrorCode;
+import lombok.Getter;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+public enum CertificateIndex {
+
+    JEONGBOCHEORIGISA("jeongbocheorigisa", 1L),
+    ;
+
+    // indexName을 반환하는 getter 메소드
+    @Getter
+    private String indexName;
+    private Long certificateId;
+
+    CertificateIndex(String indexName, Long certificateId) {
+        this.indexName = indexName;
+        this.certificateId = certificateId;
+    }
+
+    public static CertificateIndex findByCertificateId(Long certificateId) {
+        return Arrays.stream(CertificateIndex.values())
+                .filter(certificate -> Objects.equals(certificate.certificateId, certificateId))
+                .findFirst()
+                .orElseThrow(() -> new CertificateBusinessException(CommonErrorCode.INTERNAL_SERVER_ERROR));
+    }
+}

--- a/jabiseo-infrastructure/src/main/java/com/jabiseo/opensearch/OpenSearchClientConfig.java
+++ b/jabiseo-infrastructure/src/main/java/com/jabiseo/opensearch/OpenSearchClientConfig.java
@@ -1,0 +1,54 @@
+package com.jabiseo.opensearch;
+
+import com.jabiseo.common.exception.BusinessException;
+import com.jabiseo.common.exception.CommonErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.hc.client5.http.auth.AuthScope;
+import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
+import org.apache.hc.client5.http.impl.auth.BasicCredentialsProvider;
+import org.apache.hc.core5.http.HttpHost;
+import org.opensearch.client.json.jackson.JacksonJsonpMapper;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.transport.httpclient5.ApacheHttpClient5Transport;
+import org.opensearch.client.transport.httpclient5.ApacheHttpClient5TransportBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.net.URISyntaxException;
+
+@Configuration
+@Slf4j
+public class OpenSearchClientConfig {
+
+    @Value("${opensearch.url}")
+    private String openSearchUrl;
+
+    @Value("${opensearch.username}")
+    private String openSearchUsername;
+
+    @Value("${opensearch.password}")
+    private String openSearchPassword;
+
+    @Bean
+    public OpenSearchClient openSearchClient() {
+
+        HttpHost host;
+        try {
+             host = HttpHost.create(openSearchUrl);
+        } catch (URISyntaxException e) {
+            log.error("OpenSearchClientConfig openSearchClient error: {}", e.getMessage());
+            throw new BusinessException(CommonErrorCode.INTERNAL_SERVER_ERROR);
+        }
+
+        ApacheHttpClient5Transport transport = ApacheHttpClient5TransportBuilder.builder(host)
+                .setMapper(new JacksonJsonpMapper())
+                .setHttpClientConfigCallback(httpClientBuilder -> {
+                    BasicCredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+                    credentialsProvider.setCredentials(new AuthScope(host), new UsernamePasswordCredentials(openSearchUsername, openSearchPassword.toCharArray()));
+                    return httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider);
+                })
+                .build();
+        return new OpenSearchClient(transport);
+    }
+}

--- a/jabiseo-infrastructure/src/main/java/com/jabiseo/opensearch/SimilarProblemsProvider.java
+++ b/jabiseo-infrastructure/src/main/java/com/jabiseo/opensearch/SimilarProblemsProvider.java
@@ -1,0 +1,122 @@
+package com.jabiseo.opensearch;
+
+import com.jabiseo.client.NetworkApiErrorCode;
+import com.jabiseo.client.NetworkApiException;
+import com.jabiseo.opensearch.redis.SimilarProblemIdCache;
+import com.jabiseo.opensearch.redis.SimilarProblemIdCacheRepository;
+import jakarta.json.JsonNumber;
+import lombok.RequiredArgsConstructor;
+import org.opensearch.client.json.JsonData;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch.core.GetRequest;
+import org.opensearch.client.opensearch.core.GetResponse;
+import org.opensearch.client.opensearch.core.SearchRequest;
+import org.opensearch.client.opensearch.core.SearchResponse;
+import org.opensearch.client.opensearch.core.search.Hit;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.IntStream;
+
+@Component
+@RequiredArgsConstructor
+public class SimilarProblemsProvider {
+
+    private static final String INDEX_NAME = "jabiseo_problems";
+    private static final int KNN_K = 3;
+
+    private final SimilarProblemIdCacheRepository similarProblemIdCacheRepository;
+    private final OpenSearchClient openSearchClient;
+
+    public List<Long> getSimilarProblems(Long problemId, int similarProblemsSize) {
+        return similarProblemIdCacheRepository.findById(problemId)
+                .orElseGet(() -> fetchAndCacheSimilarProblems(problemId, similarProblemsSize))
+                .getSimilarProblemIds();
+    }
+
+    private SimilarProblemIdCache fetchAndCacheSimilarProblems(Long problemId, int similarProblemsSize) {
+        float[] vector = fetchProblemVector(problemId);
+        List<Long> similarProblemIds = searchSimilarProblems(vector, similarProblemsSize);
+
+        // Save to cache and return
+        SimilarProblemIdCache cache = new SimilarProblemIdCache(problemId, similarProblemIds);
+        return similarProblemIdCacheRepository.save(cache);
+    }
+
+    private float[] fetchProblemVector(Long problemId) {
+        GetResponse<JsonData> getResponse = getProblemFromOpenSearch(problemId);
+        double[] doubleVector = parseVectorFromResponse(getResponse);
+
+        return convertToFloatArray(doubleVector);
+    }
+
+    private GetResponse<JsonData> getProblemFromOpenSearch(Long problemId) {
+        try {
+            return openSearchClient.get(GetRequest.of(getReq ->
+                    getReq.index(INDEX_NAME).id(String.valueOf(problemId))
+            ), JsonData.class);
+        } catch (IOException e) {
+            throw new NetworkApiException(NetworkApiErrorCode.OPENSEARCH_API_FAIL);
+        }
+    }
+
+    private double[] parseVectorFromResponse(GetResponse<JsonData> getResponse) {
+        return getResponse.source()
+                .toJson()
+                .asJsonObject()
+                .get("problem_vector")
+                .asJsonArray()
+                .stream()
+                .map(JsonNumber.class::cast)
+                .mapToDouble(JsonNumber::doubleValue)
+                .toArray();
+    }
+
+    private float[] convertToFloatArray(double[] doubleVector) {
+        float[] vector = new float[doubleVector.length];
+        IntStream.range(0, doubleVector.length)
+                .forEach(i -> vector[i] = (float) doubleVector[i]);
+        return vector;
+    }
+
+    private List<Long> searchSimilarProblems(float[] vector, int similarProblemsSize) {
+        SearchRequest searchRequest = createSearchRequest(vector, similarProblemsSize);
+        SearchResponse<JsonData> searchResponse = executeSearch(searchRequest);
+        return extractSimilarProblemIds(searchResponse);
+    }
+
+    private SearchRequest createSearchRequest(float[] vector, int similarProblemsSize) {
+        return SearchRequest.of(searchRequest ->
+                searchRequest.index(INDEX_NAME)
+                        .size(similarProblemsSize + 1)
+                        .source(source -> source
+                                // id만 필요하므로 나머지 필드는 제외
+                                .filter(filter -> filter.includes("")))
+                        .query(query -> query
+                                .knn(knn -> knn
+                                        .field("problem_vector")
+                                        .vector(vector)
+                                        .k(KNN_K)
+                                )
+                        )
+        );
+    }
+
+    private SearchResponse<JsonData> executeSearch(SearchRequest searchRequest) {
+        try {
+            return openSearchClient.search(searchRequest, JsonData.class);
+        } catch (IOException e) {
+            throw new NetworkApiException(NetworkApiErrorCode.OPENSEARCH_API_FAIL);
+        }
+    }
+
+    private List<Long> extractSimilarProblemIds(SearchResponse<JsonData> searchResponse) {
+        return searchResponse.hits().hits().stream()
+                .map(Hit::id)
+                .map(Long::parseLong)
+                .skip(1) // 첫 번쨰 원소는 원래 문제 자체이므로 스킵
+                .limit(KNN_K)
+                .toList();
+    }
+}

--- a/jabiseo-infrastructure/src/main/java/com/jabiseo/opensearch/SimilarProblemsProvider.java
+++ b/jabiseo-infrastructure/src/main/java/com/jabiseo/opensearch/SimilarProblemsProvider.java
@@ -53,8 +53,10 @@ public class SimilarProblemsProvider {
 
     private GetResponse<JsonData> getProblemFromOpenSearch(Long problemId) {
         try {
-            return openSearchClient.get(GetRequest.of(getReq ->
-                    getReq.index(INDEX_NAME).id(String.valueOf(problemId))
+            return openSearchClient.get(GetRequest.of(getReq -> getReq
+                    .index(INDEX_NAME)
+                    .id(String.valueOf(problemId))
+                    .sourceIncludes(VECTOR_NAME)
             ), JsonData.class);
         } catch (IOException e) {
             throw new NetworkApiException(NetworkApiErrorCode.OPENSEARCH_API_FAIL);

--- a/jabiseo-infrastructure/src/main/java/com/jabiseo/opensearch/redis/SimilarProblemIdCache.java
+++ b/jabiseo-infrastructure/src/main/java/com/jabiseo/opensearch/redis/SimilarProblemIdCache.java
@@ -1,0 +1,20 @@
+package com.jabiseo.opensearch.redis;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+import java.util.List;
+
+@RedisHash(value = "similarProblemId", timeToLive = 2592000)
+@Getter
+@AllArgsConstructor
+public class SimilarProblemIdCache {
+
+    @Id
+    private Long problemId;
+
+    private List<Long> similarProblemIds;
+
+}

--- a/jabiseo-infrastructure/src/main/java/com/jabiseo/opensearch/redis/SimilarProblemIdCacheRepository.java
+++ b/jabiseo-infrastructure/src/main/java/com/jabiseo/opensearch/redis/SimilarProblemIdCacheRepository.java
@@ -1,0 +1,6 @@
+package com.jabiseo.opensearch.redis;
+
+import org.springframework.data.repository.CrudRepository;
+
+public interface SimilarProblemIdCacheRepository extends CrudRepository<SimilarProblemIdCache, Long> {
+}

--- a/jabiseo-infrastructure/src/main/resources/infra.yml
+++ b/jabiseo-infrastructure/src/main/resources/infra.yml
@@ -25,6 +25,11 @@ cloud:
 cloudfront:
   url: ${CLOUD_FRONT_URL}
 
+opensearch:
+    url: ${OPENSEARCH_URL}
+    username: ${OPENSEARCH_USERNAME}
+    password: ${OPENSEARCH_PASSWORD}
+
 ---
 spring:
   config:

--- a/jabiseo-infrastructure/src/test/java/com/jabiseo/opensearch/SimilarProblemsProviderTest.java
+++ b/jabiseo-infrastructure/src/test/java/com/jabiseo/opensearch/SimilarProblemsProviderTest.java
@@ -1,0 +1,73 @@
+package com.jabiseo.opensearch;
+
+import com.jabiseo.client.NetworkApiErrorCode;
+import com.jabiseo.client.NetworkApiException;
+import com.jabiseo.opensearch.redis.SimilarProblemIdCache;
+import com.jabiseo.opensearch.redis.SimilarProblemIdCacheRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch.core.GetRequest;
+import org.opensearch.client.opensearch.core.SearchRequest;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@DisplayName("유사 문제 기능 테스트")
+@ExtendWith(MockitoExtension.class)
+class SimilarProblemsProviderTest {
+
+    @InjectMocks
+    SimilarProblemsProvider sut;
+
+    @Mock
+    SimilarProblemIdCacheRepository similarProblemIdCacheRepository;
+
+    @Mock
+    OpenSearchClient openSearchClient;
+
+    @Test
+    @DisplayName("redis 캐시에 유사 문제 id가 저장되어 있는 경우 Opensearch와 통신하지 않는다.")
+    void givenCachedProblemId_whenFindSimilarProblemIds_thenDontConnectWithOpenSearch() throws Exception {
+        //given
+        Long problemId = 1L;
+        int similarProblemsSize = 3;
+        given(similarProblemIdCacheRepository.findById(problemId))
+                .willReturn(Optional.of(new SimilarProblemIdCache(problemId, List.of(2L, 3L, 4L))));
+
+        //when
+        sut.getSimilarProblems(problemId, similarProblemsSize);
+
+        //then
+        verify(openSearchClient, never()).get((GetRequest) any(), any());
+        verify(openSearchClient, never()).search((SearchRequest) any(), any());
+    }
+
+    @Test
+    @DisplayName("opensearch에 문제 벡터 조회 시 오류가 발생하면 NetworkApiException을 던진다.")
+    void givenErrorInOpenSearchConnection_whenFindSimilarProblems_thenThrowNetworkApiException() throws Exception {
+        //given
+        Long problemId = 1L;
+        int similarProblemsSize = 3;
+
+        given(similarProblemIdCacheRepository.findById(problemId)).willReturn(Optional.empty());
+        given(openSearchClient.get((GetRequest) any(), any())).willThrow(new IOException());
+
+        //when & then
+        assertThatThrownBy(() -> sut.getSimilarProblems(problemId, similarProblemsSize))
+                .isInstanceOf(NetworkApiException.class)
+                .hasFieldOrPropertyWithValue("errorCode", NetworkApiErrorCode.OPENSEARCH_API_FAIL);
+    }
+
+}

--- a/jabiseo-infrastructure/src/test/java/com/jabiseo/opensearch/SimilarProblemsProviderTest.java
+++ b/jabiseo-infrastructure/src/test/java/com/jabiseo/opensearch/SimilarProblemsProviderTest.java
@@ -41,13 +41,14 @@ class SimilarProblemsProviderTest {
     @DisplayName("redis 캐시에 유사 문제 id가 저장되어 있는 경우 Opensearch와 통신하지 않는다.")
     void givenCachedProblemId_whenFindSimilarProblemIds_thenDontConnectWithOpenSearch() throws Exception {
         //given
-        Long problemId = 1L;
+        Long certificateId = 1L; //정보처리기사
+        Long problemId = 2L;
         int similarProblemsSize = 3;
         given(similarProblemIdCacheRepository.findById(problemId))
                 .willReturn(Optional.of(new SimilarProblemIdCache(problemId, List.of(2L, 3L, 4L))));
 
         //when
-        sut.getSimilarProblems(problemId, similarProblemsSize);
+        sut.getSimilarProblems(problemId, certificateId, similarProblemsSize);
 
         //then
         verify(openSearchClient, never()).get((GetRequest) any(), any());
@@ -58,14 +59,15 @@ class SimilarProblemsProviderTest {
     @DisplayName("opensearch에 문제 벡터 조회 시 오류가 발생하면 NetworkApiException을 던진다.")
     void givenErrorInOpenSearchConnection_whenFindSimilarProblems_thenThrowNetworkApiException() throws Exception {
         //given
-        Long problemId = 1L;
+        Long certificateId = 1L; //정보처리기사
+        Long problemId = 2L;
         int similarProblemsSize = 3;
 
         given(similarProblemIdCacheRepository.findById(problemId)).willReturn(Optional.empty());
         given(openSearchClient.get((GetRequest) any(), any())).willThrow(new IOException());
 
         //when & then
-        assertThatThrownBy(() -> sut.getSimilarProblems(problemId, similarProblemsSize))
+        assertThatThrownBy(() -> sut.getSimilarProblems(problemId, certificateId, similarProblemsSize))
                 .isInstanceOf(NetworkApiException.class)
                 .hasFieldOrPropertyWithValue("errorCode", NetworkApiErrorCode.OPENSEARCH_API_FAIL);
     }


### PR DESCRIPTION
## PR 변경된 내용
### 문제 상세 조회 API
- 관련 QueryDSL 쿼리 추가

### 유사 문제 조회 API
- AWS OpenSearch 사용
- OpenSearch 구성 완료
  - OpenSearch 에는 문제의 특성 벡터들 존재. 해당 벡터들은 GPT로 임베딩한 결과
  - 정확성이 떨어지는 상태이므로 벡터값은 추후 변경 예정
  - 벡터값의 코사인 유사도를 계산해 가까운 벡터일수록 유사하다고 판단
- SimilarProblemsProvider 클래스를 통해 AWS와 통신
  1. 캐시에 검색 대상 문제의 유사 문제 목록이 있는지 확인
  2. 없으면 OpenSearch와 통신해서 "검색 대상 문제 벡터 조회"와 "유사 문제 조회"를 실시하고, 결과를 캐시에 저장함. 이 때 자격증마다 다른 인덱스를 가지도록 함. (OpenSearch에서 인덱스는 데이터베이스에 대응되는 개념)

  - 검색 대상 문제 벡터 조회
  검색 대상 문제의 벡터값을 가져옴. 이 때, 유사 문제 검색 메소드의 벡터 입력값이 float[]이므로 벡터값을 가져와서 float[] 으로 변환.
    - stream 등을 통해 float[]로 변환하는 메소드가 존재하지 않음. int[], long[], double[] 만 존재. 따라서 아래와 같이 변환
    ```java
    //Float[] -> float[] 변환
    float[] vector = new float[problemVector.size()];
    IntStream.range(0, problemVector.size()).forEach(i -> vector[i] = problemVector.get(i));
    ```
  - 유사 문제 조회
  검색 대상 문제 벡터값을 사용해 유사 문제 ID를 조회. 이 때 쿼리를 날리면 유사도가 가장 높은 문제는 자기 자신이므로, (가져올 문제 개수 + 1)만큼에 대한 쿼리를 날리고 첫 번째 원소는 스킵하도록 구현
    ```java
    // 검색 결과에서 유사 문제 ID 추출
    return searchResponse.hits().hits().stream()
            .map(Hit::id)
            .map(Long::parseLong)
            .skip(1) // 첫 번쨰 원소는 원래 문제 자체이므로 스킵
            .limit(KNN_K)
            .toList();  
    ```

## 추가 내용
- 단순한 문자 연결을 StringBuilder에서 String으로 변경
- 로그 레벨 다수 변경 (개발자가 의도한 오류를 INFO레벨로 변경)
- dto 이름 변경

## 참조
Closes #60 
