### PR TITLE
Feat(Plan): 플랜 entity, 생성, 조회 구현

### DIFF
--- a/jabiseo-api/src/main/java/com/jabiseo/learning/application/usecase/CreateLearningUseCase.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/learning/application/usecase/CreateLearningUseCase.java
@@ -9,6 +9,7 @@ import com.jabiseo.learning.dto.CreateLearningRequest;
 import com.jabiseo.learning.dto.ProblemResultRequest;
 import com.jabiseo.member.domain.Member;
 import com.jabiseo.member.domain.MemberRepository;
+import com.jabiseo.plan.domain.PlanProgressService;
 import com.jabiseo.problem.domain.Problem;
 import com.jabiseo.problem.domain.ProblemRepository;
 import com.jabiseo.problem.exception.ProblemBusinessException;
@@ -31,6 +32,7 @@ public class CreateLearningUseCase {
     private final ProblemRepository problemRepository;
     private final LearningRepository learningRepository;
     private final ProblemSolvingRepository problemSolvingRepository;
+    private final PlanProgressService planProgressService;
 
     public Long execute(Long memberId, CreateLearningRequest request) {
 
@@ -53,7 +55,7 @@ public class CreateLearningUseCase {
         //ProblemSolving 생성 및 저장
         List<ProblemSolving> problemSolvings = createProblemSolvings(request, solvedProblems, member, learning);
         problemSolvingRepository.saveAll(problemSolvings);
-
+        planProgressService.updateProgress(learning, problemSolvings.size());
         return learning.getId();
     }
 

--- a/jabiseo-api/src/main/java/com/jabiseo/learning/application/usecase/CreateLearningUseCase.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/learning/application/usecase/CreateLearningUseCase.java
@@ -41,7 +41,7 @@ public class CreateLearningUseCase {
 
         validateDuplicatedSolving(request);
 
-        Learning learning = Learning.of(LearningMode.valueOf(request.learningMode()), request.learningTime(), certificate);
+        Learning learning = Learning.of(LearningMode.valueOf(request.learningMode()), request.learningTime(), certificate, member);
         learningRepository.save(learning);
 
         //문제들의 id 리스트를 뽑아내 한 번의 쿼리로 찾아옴

--- a/jabiseo-api/src/main/java/com/jabiseo/plan/application/usecase/CreatePlanUseCase.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/plan/application/usecase/CreatePlanUseCase.java
@@ -1,0 +1,52 @@
+package com.jabiseo.plan.application.usecase;
+
+import com.jabiseo.member.domain.Member;
+import com.jabiseo.member.domain.MemberRepository;
+import com.jabiseo.plan.domain.*;
+import com.jabiseo.plan.dto.CreatePlanRequest;
+import com.jabiseo.plan.exception.PlanBusinessException;
+import com.jabiseo.plan.exception.PlanErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CreatePlanUseCase {
+
+    private final MemberRepository memberRepository;
+    private final PlanRepository planRepository;
+    private final PlanItemRepository planItemRepository;
+
+    public Long execute(Long memberId, CreatePlanRequest request) {
+        Member member = memberRepository.getReferenceById(memberId);
+        member.validateCurrentCertificate();
+
+        if (isInProgressPlanExists(member)) {
+            throw new PlanBusinessException(PlanErrorCode.ALREADY_EXIST_PLAN);
+        }
+
+        Plan plan = Plan.create(member, request.endDay());
+        List<PlanItem> planItems = generatePlanItems(request, plan);
+        planRepository.save(plan);
+        planItemRepository.saveAll(planItems);
+        return plan.getId();
+    }
+
+    private List<PlanItem> generatePlanItems(CreatePlanRequest request, Plan plan) {
+        List<PlanItem> planItems = new ArrayList<>();
+        request.dailyPlan().forEach((p) -> planItems.add(new PlanItem(plan, ActivityType.valueOf(p.activityType()), GoalType.DAILY)));
+        request.weeklyPlan().forEach((p) -> planItems.add(new PlanItem(plan, ActivityType.valueOf(p.activityType()), GoalType.WEEKLY)));
+        return planItems;
+    }
+
+    private boolean isInProgressPlanExists(Member member) {
+        return planRepository.existsByCertificateAndMemberAndEndAtAfter(member.getCurrentCertificate(), member, LocalDate.now());
+    }
+
+}

--- a/jabiseo-api/src/main/java/com/jabiseo/plan/application/usecase/CreatePlanUseCase.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/plan/application/usecase/CreatePlanUseCase.java
@@ -4,14 +4,11 @@ import com.jabiseo.member.domain.Member;
 import com.jabiseo.member.domain.MemberRepository;
 import com.jabiseo.plan.domain.*;
 import com.jabiseo.plan.dto.CreatePlanRequest;
-import com.jabiseo.plan.exception.PlanBusinessException;
-import com.jabiseo.plan.exception.PlanErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -20,33 +17,20 @@ import java.util.List;
 public class CreatePlanUseCase {
 
     private final MemberRepository memberRepository;
-    private final PlanRepository planRepository;
-    private final PlanItemRepository planItemRepository;
+    private final PlanService planService;
+    private final PlanProgressService planProgressService;
 
     public Long execute(Long memberId, CreatePlanRequest request) {
         Member member = memberRepository.getReferenceById(memberId);
         member.validateCurrentCertificate();
-
-        if (isInProgressPlanExists(member)) {
-            throw new PlanBusinessException(PlanErrorCode.ALREADY_EXIST_PLAN);
-        }
+        planService.checkInProgressPlan(member, LocalDate.now());
 
         Plan plan = Plan.create(member, request.endDay());
-        List<PlanItem> planItems = generatePlanItems(request, plan);
-        planRepository.save(plan);
-        planItemRepository.saveAll(planItems);
-        return plan.getId();
-    }
+        List<PlanItem> planItems = request.toPlanItems(plan);
 
-    private List<PlanItem> generatePlanItems(CreatePlanRequest request, Plan plan) {
-        List<PlanItem> planItems = new ArrayList<>();
-        request.dailyPlan().forEach((p) -> planItems.add(new PlanItem(plan, ActivityType.valueOf(p.activityType()), GoalType.DAILY, p.targetValue())));
-        request.weeklyPlan().forEach((p) -> planItems.add(new PlanItem(plan, ActivityType.valueOf(p.activityType()), GoalType.WEEKLY, p.targetValue())));
-        return planItems;
-    }
-
-    private boolean isInProgressPlanExists(Member member) {
-        return planRepository.existsByCertificateAndMemberAndEndAtAfter(member.getCurrentCertificate(), member, LocalDate.now());
+        Plan savedPlan = planService.savePlanAndItems(plan, planItems);
+        planProgressService.createCurrentPlanProgress(member, planItems);
+        return savedPlan.getId();
     }
 
 }

--- a/jabiseo-api/src/main/java/com/jabiseo/plan/application/usecase/CreatePlanUseCase.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/plan/application/usecase/CreatePlanUseCase.java
@@ -40,8 +40,8 @@ public class CreatePlanUseCase {
 
     private List<PlanItem> generatePlanItems(CreatePlanRequest request, Plan plan) {
         List<PlanItem> planItems = new ArrayList<>();
-        request.dailyPlan().forEach((p) -> planItems.add(new PlanItem(plan, ActivityType.valueOf(p.activityType()), GoalType.DAILY)));
-        request.weeklyPlan().forEach((p) -> planItems.add(new PlanItem(plan, ActivityType.valueOf(p.activityType()), GoalType.WEEKLY)));
+        request.dailyPlan().forEach((p) -> planItems.add(new PlanItem(plan, ActivityType.valueOf(p.activityType()), GoalType.DAILY, p.targetValue())));
+        request.weeklyPlan().forEach((p) -> planItems.add(new PlanItem(plan, ActivityType.valueOf(p.activityType()), GoalType.WEEKLY, p.targetValue())));
         return planItems;
     }
 

--- a/jabiseo-api/src/main/java/com/jabiseo/plan/application/usecase/FindActivePlanUseCase.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/plan/application/usecase/FindActivePlanUseCase.java
@@ -11,7 +11,6 @@ import com.jabiseo.plan.dto.PlanItemResponse;
 import com.jabiseo.plan.exception.PlanBusinessException;
 import com.jabiseo.plan.exception.PlanErrorCode;
 import com.jabiseo.problem.dto.CertificateResponse;
-import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/jabiseo-api/src/main/java/com/jabiseo/plan/application/usecase/FindActivePlanUseCase.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/plan/application/usecase/FindActivePlanUseCase.java
@@ -1,0 +1,48 @@
+package com.jabiseo.plan.application.usecase;
+
+import com.jabiseo.member.domain.Member;
+import com.jabiseo.member.domain.MemberRepository;
+import com.jabiseo.plan.domain.GoalType;
+import com.jabiseo.plan.domain.Plan;
+import com.jabiseo.plan.domain.PlanItem;
+import com.jabiseo.plan.domain.PlanRepository;
+import com.jabiseo.plan.dto.ActivePlanResponse;
+import com.jabiseo.plan.dto.PlanItemResponse;
+import com.jabiseo.plan.exception.PlanBusinessException;
+import com.jabiseo.plan.exception.PlanErrorCode;
+import com.jabiseo.problem.dto.CertificateResponse;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class FindActivePlanUseCase {
+
+    private final MemberRepository memberRepository;
+    private final PlanRepository planRepository;
+
+    public ActivePlanResponse execute(Long memberId) {
+        Member member = memberRepository.getReferenceById(memberId);
+        member.validateCurrentCertificate();
+
+        Plan plan = planRepository.findFirstByCertificateAndMember(member.getCurrentCertificate(), member)
+                .orElseThrow(() -> new PlanBusinessException(PlanErrorCode.NOT_FOUND_PLAN));
+
+        List<PlanItem> planItems = plan.getPlanItems();
+
+        return ActivePlanResponse.builder()
+                .planId(plan.getId())
+                .certificate(CertificateResponse.from(plan.getCertificate()))
+                .endAt(plan.getEndAt())
+                .weeklyPlanItems(planItems.stream().filter((p -> p.getGoalType().equals(GoalType.WEEKLY))).map(PlanItemResponse::from).toList())
+                .dailyPlanItems(planItems.stream().filter((p -> p.getGoalType().equals(GoalType.DAILY))).map(PlanItemResponse::from).toList())
+                .build();
+    }
+
+}

--- a/jabiseo-api/src/main/java/com/jabiseo/plan/application/usecase/PlanCalenderSearchUseCase.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/plan/application/usecase/PlanCalenderSearchUseCase.java
@@ -1,0 +1,22 @@
+package com.jabiseo.plan.application.usecase;
+
+import com.jabiseo.plan.dto.calender.PlanCalenderSearchResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PlanCalenderSearchUseCase {
+
+
+    public PlanCalenderSearchResponse execute(Long planId, int year, int month) {
+
+
+        return null;
+    }
+
+
+}

--- a/jabiseo-api/src/main/java/com/jabiseo/plan/application/usecase/PlanCalenderSearchUseCase.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/plan/application/usecase/PlanCalenderSearchUseCase.java
@@ -1,9 +1,19 @@
 package com.jabiseo.plan.application.usecase;
 
+import com.jabiseo.plan.domain.*;
 import com.jabiseo.plan.dto.calender.PlanCalenderSearchResponse;
+import com.jabiseo.plan.dto.calender.PlanProgressDateResponse;
+import com.jabiseo.plan.dto.calender.PlanProgressResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.OptionalInt;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 
 @Service
@@ -11,11 +21,60 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class PlanCalenderSearchUseCase {
 
+    private final PlanProgressService planProgressService;
+    private final PlanRepository planRepository;
+    private final WeeklyDefineStrategy weeklyDefineStrategy;
 
     public PlanCalenderSearchResponse execute(Long planId, int year, int month) {
+        Plan plan = planRepository.getReferenceById(planId);
+        List<PlanProgress> progress = planProgressService.findByYearMonth(plan, year, month);
 
+        List<WeekPeriod> periodPerWeek = weeklyDefineStrategy.getPeriodPerWeek(year, month);
+        List<PlanProgressDateResponse> daily = dailyProgressCovert(progress);
+        List<PlanProgressDateResponse> weekly = weeklyProgressCovert(progress, periodPerWeek);
 
-        return null;
+        return new PlanCalenderSearchResponse(year, month, daily, weekly);
+    }
+
+    private List<PlanProgressDateResponse> weeklyProgressCovert(List<PlanProgress> progressList, List<WeekPeriod> weekPeriods) {
+        Map<LocalDate, List<PlanProgress>> map = progressList.stream().filter(planProgress -> planProgress.getGoalType().equals(GoalType.WEEKLY))
+                .collect(Collectors.groupingBy(PlanProgress::getProgressDate, Collectors.toList()));
+
+        return map.entrySet().stream()
+                .sorted()
+                .map(entry -> {
+                    List<PlanProgressResponse> list = entry.getValue()
+                            .stream()
+                            .map((v) -> new PlanProgressResponse(v.getActivityType(), v.getCompletedValue(), v.getTargetValue()))
+                            .toList();
+                    return PlanProgressDateResponse.ofWeek(findIndexWeek(weekPeriods, entry.getKey()) + 1, list);
+                }).toList();
+    }
+
+    private static int findIndexWeek(List<WeekPeriod> weekPeriods, LocalDate date) {
+        OptionalInt index = IntStream.range(0, weekPeriods.size())
+                .filter(i -> {
+                    WeekPeriod period = weekPeriods.get(i);
+                    return !date.isBefore(period.getStart()) && !date.isAfter(period.getEnd());
+                })
+                .findFirst();
+
+        return index.orElse(-1);
+    }
+
+    private List<PlanProgressDateResponse> dailyProgressCovert(List<PlanProgress> progressList) {
+        Map<LocalDate, List<PlanProgress>> map = progressList.stream().filter(planProgress -> planProgress.getGoalType().equals(GoalType.DAILY))
+                .collect(Collectors.groupingBy(PlanProgress::getProgressDate, Collectors.toList()));
+
+        return map.entrySet().stream()
+                .sorted()
+                .map(entry -> {
+                    List<PlanProgressResponse> list = entry.getValue()
+                            .stream()
+                            .map((v) -> new PlanProgressResponse(v.getActivityType(), v.getCompletedValue(), v.getTargetValue()))
+                            .toList();
+                    return PlanProgressDateResponse.ofDay(entry.getKey(), list);
+                }).toList();
     }
 
 

--- a/jabiseo-api/src/main/java/com/jabiseo/plan/controller/PlanController.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/plan/controller/PlanController.java
@@ -4,7 +4,7 @@ import com.jabiseo.config.auth.AuthMember;
 import com.jabiseo.config.auth.AuthenticatedMember;
 import com.jabiseo.plan.application.usecase.CreatePlanUseCase;
 import com.jabiseo.plan.application.usecase.FindActivePlanUseCase;
-import com.jabiseo.plan.application.usecase.PlanCalenderSearchUseCase;
+import com.jabiseo.plan.application.usecase.SearchPlanCalenderUseCase;
 import com.jabiseo.plan.dto.ActivePlanResponse;
 import com.jabiseo.plan.dto.CreatePlanRequest;
 import com.jabiseo.plan.dto.calender.PlanCalenderSearchResponse;
@@ -23,7 +23,7 @@ public class PlanController {
 
     private final CreatePlanUseCase createPlanUseCase;
     private final FindActivePlanUseCase findActivePlanUseCase;
-    private final PlanCalenderSearchUseCase planCalenderSearchUseCase;
+    private final SearchPlanCalenderUseCase searchPlanCalenderUseCase;
 
     @PostMapping
     public ResponseEntity<Void> create(@Valid @RequestBody CreatePlanRequest request, @AuthenticatedMember AuthMember member) {
@@ -49,7 +49,7 @@ public class PlanController {
                                                                       @PathVariable("id") Long planId,
                                                                       @RequestParam(name = "year") int year,
                                                                       @RequestParam(name = "month") int month) {
-        PlanCalenderSearchResponse result = planCalenderSearchUseCase.execute(planId, year, month);
+        PlanCalenderSearchResponse result = searchPlanCalenderUseCase.execute(member.getMemberId(), planId, year, month);
         return ResponseEntity.ok(result);
     }
 }

--- a/jabiseo-api/src/main/java/com/jabiseo/plan/controller/PlanController.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/plan/controller/PlanController.java
@@ -3,14 +3,13 @@ package com.jabiseo.plan.controller;
 import com.jabiseo.config.auth.AuthMember;
 import com.jabiseo.config.auth.AuthenticatedMember;
 import com.jabiseo.plan.application.usecase.CreatePlanUseCase;
+import com.jabiseo.plan.application.usecase.FindActivePlanUseCase;
+import com.jabiseo.plan.dto.ActivePlanResponse;
 import com.jabiseo.plan.dto.CreatePlanRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.net.URI;
@@ -21,6 +20,7 @@ import java.net.URI;
 public class PlanController {
 
     private final CreatePlanUseCase createPlanUseCase;
+    private final FindActivePlanUseCase findActivePlanUseCase;
 
     @PostMapping
     public ResponseEntity<Void> create(@Valid @RequestBody CreatePlanRequest request, @AuthenticatedMember AuthMember member) {
@@ -33,5 +33,11 @@ public class PlanController {
                 .toUri();
 
         return ResponseEntity.created(location).build();
+    }
+
+    @GetMapping("/active")
+    public ResponseEntity<ActivePlanResponse> getActive(@AuthenticatedMember AuthMember member) {
+        ActivePlanResponse result = findActivePlanUseCase.execute(member.getMemberId());
+        return ResponseEntity.ok(result);
     }
 }

--- a/jabiseo-api/src/main/java/com/jabiseo/plan/controller/PlanController.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/plan/controller/PlanController.java
@@ -4,8 +4,10 @@ import com.jabiseo.config.auth.AuthMember;
 import com.jabiseo.config.auth.AuthenticatedMember;
 import com.jabiseo.plan.application.usecase.CreatePlanUseCase;
 import com.jabiseo.plan.application.usecase.FindActivePlanUseCase;
+import com.jabiseo.plan.application.usecase.PlanCalenderSearchUseCase;
 import com.jabiseo.plan.dto.ActivePlanResponse;
 import com.jabiseo.plan.dto.CreatePlanRequest;
+import com.jabiseo.plan.dto.calender.PlanCalenderSearchResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -21,6 +23,7 @@ public class PlanController {
 
     private final CreatePlanUseCase createPlanUseCase;
     private final FindActivePlanUseCase findActivePlanUseCase;
+    private final PlanCalenderSearchUseCase planCalenderSearchUseCase;
 
     @PostMapping
     public ResponseEntity<Void> create(@Valid @RequestBody CreatePlanRequest request, @AuthenticatedMember AuthMember member) {
@@ -38,6 +41,15 @@ public class PlanController {
     @GetMapping("/active")
     public ResponseEntity<ActivePlanResponse> getActive(@AuthenticatedMember AuthMember member) {
         ActivePlanResponse result = findActivePlanUseCase.execute(member.getMemberId());
+        return ResponseEntity.ok(result);
+    }
+
+    @GetMapping("/{id}/calender")
+    public ResponseEntity<PlanCalenderSearchResponse> getPlanCalender(@AuthenticatedMember AuthMember member,
+                                                                      @PathVariable("id") Long planId,
+                                                                      @RequestParam(name = "year") int year,
+                                                                      @RequestParam(name = "month") int month) {
+        PlanCalenderSearchResponse result = planCalenderSearchUseCase.execute(planId, year, month);
         return ResponseEntity.ok(result);
     }
 }

--- a/jabiseo-api/src/main/java/com/jabiseo/plan/controller/PlanController.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/plan/controller/PlanController.java
@@ -1,0 +1,37 @@
+package com.jabiseo.plan.controller;
+
+import com.jabiseo.config.auth.AuthMember;
+import com.jabiseo.config.auth.AuthenticatedMember;
+import com.jabiseo.plan.application.usecase.CreatePlanUseCase;
+import com.jabiseo.plan.dto.CreatePlanRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.net.URI;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/plans")
+public class PlanController {
+
+    private final CreatePlanUseCase createPlanUseCase;
+
+    @PostMapping
+    public ResponseEntity<Void> create(@Valid @RequestBody CreatePlanRequest request, @AuthenticatedMember AuthMember member) {
+        Long planId = createPlanUseCase.execute(member.getMemberId(), request);
+
+        URI location = ServletUriComponentsBuilder
+                .fromCurrentRequest()
+                .path("/{id}")
+                .buildAndExpand(planId)
+                .toUri();
+
+        return ResponseEntity.created(location).build();
+    }
+}

--- a/jabiseo-api/src/main/java/com/jabiseo/plan/dto/ActivePlanResponse.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/plan/dto/ActivePlanResponse.java
@@ -1,0 +1,19 @@
+package com.jabiseo.plan.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.jabiseo.problem.dto.CertificateResponse;
+import lombok.Builder;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Builder
+public record ActivePlanResponse(
+        Long planId,
+        CertificateResponse certificate,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+        LocalDate endAt,
+        List<PlanItemResponse> dailyPlanItems,
+        List<PlanItemResponse> weeklyPlanItems
+) {
+}

--- a/jabiseo-api/src/main/java/com/jabiseo/plan/dto/CreatePlanRequest.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/plan/dto/CreatePlanRequest.java
@@ -1,0 +1,20 @@
+package com.jabiseo.plan.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record CreatePlanRequest(
+        @Future
+        LocalDate endDay,
+
+        @NotNull @Valid
+        List<PlanItemRequest> dailyPlan,
+
+        @NotNull @Valid
+        List<PlanItemRequest> weeklyPlan
+) {
+}

--- a/jabiseo-api/src/main/java/com/jabiseo/plan/dto/CreatePlanRequest.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/plan/dto/CreatePlanRequest.java
@@ -1,10 +1,15 @@
 package com.jabiseo.plan.dto;
 
+import com.jabiseo.plan.domain.ActivityType;
+import com.jabiseo.plan.domain.GoalType;
+import com.jabiseo.plan.domain.Plan;
+import com.jabiseo.plan.domain.PlanItem;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.NotNull;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 
 public record CreatePlanRequest(
@@ -17,4 +22,11 @@ public record CreatePlanRequest(
         @NotNull @Valid
         List<PlanItemRequest> weeklyPlan
 ) {
+
+    public List<PlanItem> toPlanItems(Plan plan) {
+        List<PlanItem> planItems = new ArrayList<>();
+        this.dailyPlan.forEach((p) -> planItems.add(new PlanItem(plan, ActivityType.valueOf(p.activityType()), GoalType.DAILY, p.targetValue())));
+        this.weeklyPlan.forEach((p) -> planItems.add(new PlanItem(plan, ActivityType.valueOf(p.activityType()), GoalType.WEEKLY, p.targetValue())));
+        return planItems;
+    }
 }

--- a/jabiseo-api/src/main/java/com/jabiseo/plan/dto/CreatePlanRequest.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/plan/dto/CreatePlanRequest.java
@@ -13,7 +13,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public record CreatePlanRequest(
-        @Future
+        @NotNull @Future
         LocalDate endDay,
 
         @NotNull @Valid

--- a/jabiseo-api/src/main/java/com/jabiseo/plan/dto/PlanItemRequest.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/plan/dto/PlanItemRequest.java
@@ -1,0 +1,11 @@
+package com.jabiseo.plan.dto;
+
+import com.jabiseo.common.validator.EnumValid;
+import com.jabiseo.plan.domain.ActivityType;
+
+public record PlanItemRequest (
+        int targetValue,
+        @EnumValid(enumClass = ActivityType.class, message = "허용된 plan activity 가 아닙니다")
+        String activityType
+){
+}

--- a/jabiseo-api/src/main/java/com/jabiseo/plan/dto/PlanItemRequest.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/plan/dto/PlanItemRequest.java
@@ -3,9 +3,9 @@ package com.jabiseo.plan.dto;
 import com.jabiseo.common.validator.EnumValid;
 import com.jabiseo.plan.domain.ActivityType;
 
-public record PlanItemRequest (
+public record PlanItemRequest(
         int targetValue,
         @EnumValid(enumClass = ActivityType.class, message = "허용된 plan activity 가 아닙니다")
         String activityType
-){
+) {
 }

--- a/jabiseo-api/src/main/java/com/jabiseo/plan/dto/PlanItemResponse.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/plan/dto/PlanItemResponse.java
@@ -4,7 +4,7 @@ import com.jabiseo.plan.domain.ActivityType;
 import com.jabiseo.plan.domain.PlanItem;
 
 public record PlanItemResponse(
-        Long planItemsId,
+        Long planItemId,
         ActivityType activityType,
         int targetValue
 ) {

--- a/jabiseo-api/src/main/java/com/jabiseo/plan/dto/PlanItemResponse.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/plan/dto/PlanItemResponse.java
@@ -1,0 +1,15 @@
+package com.jabiseo.plan.dto;
+
+import com.jabiseo.plan.domain.ActivityType;
+import com.jabiseo.plan.domain.PlanItem;
+
+public record PlanItemResponse(
+        Long planItemsId,
+        ActivityType activityType,
+        int targetValue
+) {
+
+    public static PlanItemResponse from(PlanItem planItem) {
+        return new PlanItemResponse(planItem.getId(), planItem.getActivityType(), planItem.getTargetValue());
+    }
+}

--- a/jabiseo-api/src/main/java/com/jabiseo/plan/dto/calender/PlanCalenderSearchResponse.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/plan/dto/calender/PlanCalenderSearchResponse.java
@@ -1,0 +1,11 @@
+package com.jabiseo.plan.dto.calender;
+
+import java.util.List;
+
+public record PlanCalenderSearchResponse(
+        int year,
+        int month,
+        List<PlanProgressDateResponse> dailyProgress,
+        List<PlanProgressDateResponse> weeklyProgress
+) {
+}

--- a/jabiseo-api/src/main/java/com/jabiseo/plan/dto/calender/PlanProgressDateResponse.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/plan/dto/calender/PlanProgressDateResponse.java
@@ -1,0 +1,22 @@
+package com.jabiseo.plan.dto.calender;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record PlanProgressDateResponse(
+        LocalDate day,
+        Integer week,
+        List<PlanProgressResponse> planItems
+) {
+
+    public static PlanProgressDateResponse ofWeek(Integer week, List<PlanProgressResponse> planItems) {
+        return new PlanProgressDateResponse(null, week, planItems);
+    }
+
+    public static PlanProgressDateResponse ofDay(LocalDate day, List<PlanProgressResponse> planItems) {
+        return new PlanProgressDateResponse(day, null, planItems);
+    }
+}

--- a/jabiseo-api/src/main/java/com/jabiseo/plan/dto/calender/PlanProgressDateResponse.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/plan/dto/calender/PlanProgressDateResponse.java
@@ -1,5 +1,6 @@
 package com.jabiseo.plan.dto.calender;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import java.time.LocalDate;
@@ -7,6 +8,7 @@ import java.util.List;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record PlanProgressDateResponse(
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
         LocalDate day,
         Integer week,
         List<PlanProgressResponse> planItems

--- a/jabiseo-api/src/main/java/com/jabiseo/plan/dto/calender/PlanProgressResponse.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/plan/dto/calender/PlanProgressResponse.java
@@ -6,10 +6,10 @@ import lombok.Getter;
 @Getter
 public class PlanProgressResponse {
     ActivityType activityType;
-    Integer completedValue;
+    Long completedValue;
     Integer targetValue;
 
-    public PlanProgressResponse(ActivityType activityType, Integer completedValue, Integer targetValue) {
+    public PlanProgressResponse(ActivityType activityType, Long completedValue, Integer targetValue) {
         this.activityType = activityType;
         this.completedValue = completedValue;
         this.targetValue = targetValue;

--- a/jabiseo-api/src/main/java/com/jabiseo/plan/dto/calender/PlanProgressResponse.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/plan/dto/calender/PlanProgressResponse.java
@@ -1,0 +1,18 @@
+package com.jabiseo.plan.dto.calender;
+
+import com.jabiseo.plan.domain.ActivityType;
+import lombok.Getter;
+
+@Getter
+public class PlanProgressResponse {
+    ActivityType activityType;
+    Integer completedValue;
+    Integer targetValue;
+
+    public PlanProgressResponse(ActivityType activityType, Integer completedValue, Integer targetValue) {
+        this.activityType = activityType;
+        this.completedValue = completedValue;
+        this.targetValue = targetValue;
+    }
+
+}

--- a/jabiseo-api/src/main/java/com/jabiseo/plan/dto/calender/PlanProgressResponse.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/plan/dto/calender/PlanProgressResponse.java
@@ -1,18 +1,10 @@
 package com.jabiseo.plan.dto.calender;
 
 import com.jabiseo.plan.domain.ActivityType;
-import lombok.Getter;
 
-@Getter
-public class PlanProgressResponse {
-    ActivityType activityType;
-    Long completedValue;
-    Integer targetValue;
-
-    public PlanProgressResponse(ActivityType activityType, Long completedValue, Integer targetValue) {
-        this.activityType = activityType;
-        this.completedValue = completedValue;
-        this.targetValue = targetValue;
-    }
-
+public record PlanProgressResponse(
+        ActivityType activityType,
+        Long completedValue,
+        Integer targetValue
+) {
 }

--- a/jabiseo-api/src/test/java/com/jabiseo/learning/application/usecase/CreateLearningUseCaseTest.java
+++ b/jabiseo-api/src/test/java/com/jabiseo/learning/application/usecase/CreateLearningUseCaseTest.java
@@ -9,6 +9,7 @@ import com.jabiseo.learning.dto.CreateLearningRequest;
 import com.jabiseo.learning.dto.ProblemResultRequest;
 import com.jabiseo.member.domain.Member;
 import com.jabiseo.member.domain.MemberRepository;
+import com.jabiseo.plan.domain.PlanProgressService;
 import com.jabiseo.problem.domain.Problem;
 import com.jabiseo.problem.domain.ProblemRepository;
 import com.jabiseo.problem.exception.ProblemBusinessException;
@@ -32,6 +33,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -55,6 +57,9 @@ class CreateLearningUseCaseTest {
 
     @Mock
     ProblemSolvingRepository problemSolvingRepository;
+
+    @Mock
+    PlanProgressService planProgressService;
 
     @Test
     @DisplayName("존재하지 않는 자격증으로 학습 결과 제출 시 예외가 발생한다.")

--- a/jabiseo-domain/src/main/java/com/jabiseo/common/exception/ErrorCode.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/common/exception/ErrorCode.java
@@ -8,6 +8,8 @@ public interface ErrorCode {
 
     int UNAUTHORIZED = 401;
 
+    int CONFLICT = 409;
+
     int INTERNAL_SERVER_ERROR = 500;
 
     int FORBIDDEN = 403;

--- a/jabiseo-domain/src/main/java/com/jabiseo/learning/domain/Learning.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/learning/domain/Learning.java
@@ -1,6 +1,7 @@
 package com.jabiseo.learning.domain;
 
 import com.jabiseo.certificate.domain.Certificate;
+import com.jabiseo.member.domain.Member;
 import io.hypersistence.utils.hibernate.id.Tsid;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -35,13 +36,19 @@ public class Learning {
     @JoinColumn(name = "certificate-id", foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
     private Certificate certificate;
 
-    private Learning(LearningMode mode, Long learningTime, Certificate certificate) {
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member-id", foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
+    private Member member;
+
+
+    private Learning(LearningMode mode, Long learningTime, Certificate certificate, Member member) {
         this.mode = mode;
         this.learningTime = learningTime;
         this.certificate = certificate;
+        this.member = member;
     }
 
-    public static Learning of(LearningMode mode, Long learningTime, Certificate certificate) {
-        return new Learning(mode, learningTime, certificate);
+    public static Learning of(LearningMode mode, Long learningTime, Certificate certificate, Member member) {
+        return new Learning(mode, learningTime, certificate, member);
     }
 }

--- a/jabiseo-domain/src/main/java/com/jabiseo/learning/domain/LearningRepository.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/learning/domain/LearningRepository.java
@@ -1,6 +1,7 @@
 package com.jabiseo.learning.domain;
 
+import com.jabiseo.learning.domain.querydsl.LearningQueryDslRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface LearningRepository extends JpaRepository<Learning, Long> {
+public interface LearningRepository extends JpaRepository<Learning, Long>, LearningQueryDslRepository {
 }

--- a/jabiseo-domain/src/main/java/com/jabiseo/learning/domain/querydsl/LearningQueryDslRepository.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/learning/domain/querydsl/LearningQueryDslRepository.java
@@ -1,0 +1,13 @@
+package com.jabiseo.learning.domain.querydsl;
+
+import com.jabiseo.certificate.domain.Certificate;
+import com.jabiseo.learning.dto.LearningWithSolvingCountQueryDto;
+import com.jabiseo.member.domain.Member;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface LearningQueryDslRepository {
+
+    List<LearningWithSolvingCountQueryDto> findLearningWithSolvingCount(Member member, Certificate certificate, LocalDate startDate, LocalDate endDate);
+}

--- a/jabiseo-domain/src/main/java/com/jabiseo/learning/domain/querydsl/LearningQueryDslRepositoryImpl.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/learning/domain/querydsl/LearningQueryDslRepositoryImpl.java
@@ -1,0 +1,44 @@
+package com.jabiseo.learning.domain.querydsl;
+
+import com.jabiseo.certificate.domain.Certificate;
+import com.jabiseo.learning.dto.LearningWithSolvingCountQueryDto;
+import com.jabiseo.member.domain.Member;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static com.jabiseo.learning.domain.QLearning.learning;
+import static com.jabiseo.learning.domain.QProblemSolving.problemSolving;
+
+@Component
+@RequiredArgsConstructor
+public class LearningQueryDslRepositoryImpl implements LearningQueryDslRepository {
+
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<LearningWithSolvingCountQueryDto> findLearningWithSolvingCount(Member member, Certificate certificate, LocalDate startDate, LocalDate endDate) {
+        return queryFactory
+                .select(Projections.constructor(
+                        LearningWithSolvingCountQueryDto.class,
+                        learning.mode,
+                        learning.learningTime,  // TIMESTAMP를 Long으로 변환
+                        learning.createdAt,
+                        problemSolving.id.count().as("solvingCount") // COUNT 쿼리
+                ))
+                .from(learning)
+                .leftJoin(problemSolving).on(learning.id.eq(problemSolving.learning.id))
+                .where(
+                        learning.member.id.eq(member.getId()),
+                        learning.certificate.id.eq(certificate.getId()),
+                        learning.createdAt.between(startDate.atStartOfDay(), endDate.atTime(23, 59, 59)) // 날짜 범위 조건
+                )
+                .groupBy(learning.id) // learning 테이블의 기본 키로 그룹화
+                .fetch();
+    }
+}

--- a/jabiseo-domain/src/main/java/com/jabiseo/learning/dto/LearningWithSolvingCountQueryDto.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/learning/dto/LearningWithSolvingCountQueryDto.java
@@ -1,5 +1,6 @@
 package com.jabiseo.learning.dto;
 
+import com.jabiseo.learning.domain.Learning;
 import com.jabiseo.learning.domain.LearningMode;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -17,4 +18,8 @@ public class LearningWithSolvingCountQueryDto {
     private LocalDateTime createdAt;
     private Long solvingCount;
 
+
+    public static LearningWithSolvingCountQueryDto from(Learning learning, long count){
+        return new LearningWithSolvingCountQueryDto(learning.getMode(), learning.getLearningTime(), learning.getCreatedAt(), count);
+    }
 }

--- a/jabiseo-domain/src/main/java/com/jabiseo/learning/dto/LearningWithSolvingCountQueryDto.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/learning/dto/LearningWithSolvingCountQueryDto.java
@@ -1,0 +1,20 @@
+package com.jabiseo.learning.dto;
+
+import com.jabiseo.learning.domain.LearningMode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LearningWithSolvingCountQueryDto {
+
+    private LearningMode mode;
+    private Long learningTime;
+    private LocalDateTime createdAt;
+    private Long solvingCount;
+
+}

--- a/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/ActivityType.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/ActivityType.java
@@ -1,0 +1,5 @@
+package com.jabiseo.plan.domain;
+
+public enum ActivityType {
+    EXAM, STUDY, PROBLEM, TIME
+}

--- a/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/ActivityType.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/ActivityType.java
@@ -3,3 +3,9 @@ package com.jabiseo.plan.domain;
 public enum ActivityType {
     EXAM, STUDY, PROBLEM, TIME
 }
+/*
+*  EXAM : LearningMode EXAM 풀이 횟수
+*  STUDY : LearningMode STUDY 풀이 횟수
+*  PROBLEM : ProblemSolving 기록 횟수
+*  TIME : Learning Time 합
+*/

--- a/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/GoalType.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/GoalType.java
@@ -1,0 +1,5 @@
+package com.jabiseo.plan.domain;
+
+public enum GoalType {
+    DAILY, WEEKLY;
+}

--- a/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/Plan.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/Plan.java
@@ -8,13 +8,17 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.BatchSize;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
 @Getter
+@EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Plan {
 
@@ -36,6 +40,11 @@ public class Plan {
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "plan")
     @BatchSize(size = 100)
     private List<PlanItem> planItems = new ArrayList<>();
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
 
     public Plan(Certificate certificate, Member member, LocalDate endAt) {
         this.certificate = certificate;

--- a/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/Plan.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/Plan.java
@@ -7,6 +7,7 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -32,7 +33,8 @@ public class Plan {
 
     private LocalDate endAt;
 
-    @OneToMany(fetch = FetchType.LAZY)
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "plan")
+    @BatchSize(size = 100)
     private List<PlanItem> planItems = new ArrayList<>();
 
     public Plan(Certificate certificate, Member member, LocalDate endAt) {

--- a/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/Plan.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/Plan.java
@@ -2,6 +2,8 @@ package com.jabiseo.plan.domain;
 
 import com.jabiseo.certificate.domain.Certificate;
 import com.jabiseo.member.domain.Member;
+import com.jabiseo.plan.exception.PlanBusinessException;
+import com.jabiseo.plan.exception.PlanErrorCode;
 import io.hypersistence.utils.hibernate.id.Tsid;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -54,5 +56,11 @@ public class Plan {
 
     public static Plan create(Member member, LocalDate endAt){
         return new Plan(member.getCurrentCertificate(), member, endAt);
+    }
+
+    public void checkOwner(Long memberId) {
+        if(!memberId.equals(this.member.getId())){
+            throw new PlanBusinessException(PlanErrorCode.IS_NOT_OWNER);
+        }
     }
 }

--- a/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/Plan.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/Plan.java
@@ -1,0 +1,47 @@
+package com.jabiseo.plan.domain;
+
+import com.jabiseo.certificate.domain.Certificate;
+import com.jabiseo.member.domain.Member;
+import io.hypersistence.utils.hibernate.id.Tsid;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Plan {
+
+    @Id
+    @Tsid
+    @Column(name = "plan_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "certificate_id", foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
+    private Certificate certificate;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
+    private Member member;
+
+    private LocalDate endAt;
+
+    @OneToMany(fetch = FetchType.LAZY)
+    private List<PlanItem> planItems = new ArrayList<>();
+
+    public Plan(Certificate certificate, Member member, LocalDate endAt) {
+        this.certificate = certificate;
+        this.member = member;
+        this.endAt = endAt;
+    }
+
+    public static Plan create(Member member, LocalDate endAt){
+        return new Plan(member.getCurrentCertificate(), member, endAt);
+    }
+}

--- a/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/PlanItem.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/PlanItem.java
@@ -27,9 +27,12 @@ public class PlanItem {
     @Enumerated(EnumType.STRING)
     private GoalType goalType;
 
-    public PlanItem(Plan plan, ActivityType activityType, GoalType goalType) {
+    private int targetValue;
+
+    public PlanItem(Plan plan, ActivityType activityType, GoalType goalType, int targetValue) {
         this.plan = plan;
         this.activityType = activityType;
         this.goalType = goalType;
+        this.targetValue = targetValue;
     }
 }

--- a/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/PlanItem.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/PlanItem.java
@@ -1,0 +1,35 @@
+package com.jabiseo.plan.domain;
+
+import io.hypersistence.utils.hibernate.id.Tsid;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PlanItem {
+
+    @Id
+    @Tsid
+    @Column(name = "plan_item_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "plan_id", foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
+    private Plan plan;
+
+    @Enumerated(EnumType.STRING)
+    private ActivityType activityType;
+
+    @Enumerated(EnumType.STRING)
+    private GoalType goalType;
+
+    public PlanItem(Plan plan, ActivityType activityType, GoalType goalType) {
+        this.plan = plan;
+        this.activityType = activityType;
+        this.goalType = goalType;
+    }
+}

--- a/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/PlanItemRepository.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/PlanItemRepository.java
@@ -1,0 +1,6 @@
+package com.jabiseo.plan.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PlanItemRepository extends JpaRepository<PlanItem, Long> {
+}

--- a/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/PlanProgress.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/PlanProgress.java
@@ -3,6 +3,7 @@ package com.jabiseo.plan.domain;
 import io.hypersistence.utils.hibernate.id.Tsid;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
@@ -15,16 +16,18 @@ import java.time.LocalDateTime;
 @Getter
 @EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class PlanItem {
+public class PlanProgress {
 
     @Id
     @Tsid
-    @Column(name = "plan_item_id")
+    @Column(name = "plan_progress_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "plan_id", foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
     private Plan plan;
+
+    private LocalDate progressDate;
 
     @Enumerated(EnumType.STRING)
     private ActivityType activityType;
@@ -34,25 +37,23 @@ public class PlanItem {
 
     private Integer targetValue;
 
+    private Long completedValue;
+
     @CreatedDate
     @Column(updatable = false)
     private LocalDateTime createdAt;
 
-    public PlanItem(Plan plan, ActivityType activityType, GoalType goalType, Integer targetValue) {
+    @Builder
+    public PlanProgress(Plan plan, LocalDate progressDate, ActivityType activityType, GoalType goalType, Integer targetValue, Long completedValue) {
         this.plan = plan;
+        this.progressDate = progressDate;
         this.activityType = activityType;
         this.goalType = goalType;
         this.targetValue = targetValue;
+        this.completedValue = completedValue;
     }
 
-    public PlanProgress toPlanProgress(LocalDate progressDate) {
-        return PlanProgress.builder()
-                .plan(this.plan)
-                .progressDate(progressDate)
-                .activityType(this.activityType)
-                .goalType(this.goalType)
-                .targetValue(this.targetValue)
-                .completedValue(0L)
-                .build();
+    public void addCompletedValue(Long add) {
+        this.completedValue += add;
     }
 }

--- a/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/PlanProgressRepository.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/PlanProgressRepository.java
@@ -2,6 +2,10 @@ package com.jabiseo.plan.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
+import java.util.List;
+
 public interface PlanProgressRepository extends JpaRepository<PlanProgress, Long> {
 
+    List<PlanProgress> findAllByPlanAndProgressDateBetweenOrderByProgressDate(Plan plan, LocalDate start, LocalDate end);
 }

--- a/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/PlanProgressRepository.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/PlanProgressRepository.java
@@ -1,0 +1,7 @@
+package com.jabiseo.plan.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PlanProgressRepository extends JpaRepository<PlanProgress, Long> {
+
+}

--- a/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/PlanProgressRepository.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/PlanProgressRepository.java
@@ -8,4 +8,6 @@ import java.util.List;
 public interface PlanProgressRepository extends JpaRepository<PlanProgress, Long> {
 
     List<PlanProgress> findAllByPlanAndProgressDateBetweenOrderByProgressDate(Plan plan, LocalDate start, LocalDate end);
+
+    List<PlanProgress> findAllByProgressDateBetweenAndGoalType(LocalDate start, LocalDate end, GoalType goalType);
 }

--- a/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/PlanProgressService.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/PlanProgressService.java
@@ -22,6 +22,14 @@ public class PlanProgressService {
     private final PlanProgressRepository planProgressRepository;
     private final LearningRepository learningRepository;
 
+    public List<PlanProgress> findByYearMonth(Plan plan, int year, int month) {
+        List<WeekPeriod> periodPerWeek = weeklyDefineStrategy.getPeriodPerWeek(year, month);
+        LocalDate startQueryDate = periodPerWeek.get(0).getStart();
+        LocalDate endQueryDate = periodPerWeek.get(periodPerWeek.size() - 1).getEnd();
+
+        return planProgressRepository.findAllByPlanAndProgressDateBetweenOrderByProgressDate(plan, startQueryDate, endQueryDate);
+    }
+
     public void createCurrentPlanProgress(Member member, List<PlanItem> planItems) {
         WeekPeriod currentWeekPeriod = weeklyDefineStrategy.getCurrentWeekPeriod(LocalDate.now());
 
@@ -44,7 +52,7 @@ public class PlanProgressService {
         }
 
         List<LearningWithSolvingCountQueryDto> queryResult = learningRepository.findLearningWithSolvingCount(member, member.getCurrentCertificate(), start, end);
-        if(queryResult.isEmpty()) {
+        if (queryResult.isEmpty()) {
             return;
         }
 

--- a/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/PlanProgressService.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/PlanProgressService.java
@@ -1,0 +1,91 @@
+package com.jabiseo.plan.domain;
+
+
+import com.jabiseo.learning.domain.LearningMode;
+import com.jabiseo.learning.domain.LearningRepository;
+import com.jabiseo.learning.dto.LearningWithSolvingCountQueryDto;
+import com.jabiseo.member.domain.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class PlanProgressService {
+
+    private final WeeklyDefineStrategy weeklyDefineStrategy;
+    private final PlanProgressRepository planProgressRepository;
+    private final LearningRepository learningRepository;
+
+    public void createCurrentPlanProgress(Member member, List<PlanItem> planItems) {
+        WeekPeriod currentWeekPeriod = weeklyDefineStrategy.getCurrentWeekPeriod(LocalDate.now());
+
+        List<PlanProgress> daily = planItems.stream().filter(p -> p.getGoalType().equals(GoalType.DAILY))
+                .map(planItem -> planItem.toPlanProgress(LocalDate.now()))
+                .toList();
+
+        List<PlanProgress> weekly = planItems.stream().filter(p -> p.getGoalType().equals(GoalType.WEEKLY))
+                .map(planItem -> planItem.toPlanProgress(currentWeekPeriod.getEnd()))
+                .toList();
+
+        learningCalculateAndSave(member, daily, LocalDate.now(), LocalDate.now());
+        learningCalculateAndSave(member, weekly, currentWeekPeriod.getStart(), currentWeekPeriod.getEnd());
+    }
+
+    private void learningCalculateAndSave(Member member, List<PlanProgress> progress, LocalDate start, LocalDate end) {
+        // 없으면 진행하지 않는다.
+        if (progress.isEmpty()) {
+            return;
+        }
+
+        List<LearningWithSolvingCountQueryDto> queryResult = learningRepository.findLearningWithSolvingCount(member, member.getCurrentCertificate(), start, end);
+        if(queryResult.isEmpty()) {
+            return;
+        }
+
+        List<PlanProgress> planProgresses = calculateProgress(progress, queryResult);
+        planProgressRepository.saveAll(planProgresses);
+    }
+
+    // 테스트를 위해 package-private 구성
+    List<PlanProgress> calculateProgress(List<PlanProgress> progress, List<LearningWithSolvingCountQueryDto> learningWithSolving) {
+        // PlanProgress 가 ActivityType 당 1개임을 보장하기에 이렇게 구성
+        Map<ActivityType, PlanProgress> map = progress.stream()
+                .collect(Collectors.toMap(
+                        PlanProgress::getActivityType,
+                        Function.identity()
+                ));
+
+        // O(n)으로 처리
+        learningWithSolving.forEach(learning -> {
+            if (learning.getMode().equals(LearningMode.EXAM) && map.containsKey(ActivityType.EXAM)) {
+                PlanProgress planProgress = map.get(ActivityType.EXAM);
+                planProgress.addCompletedValue(1L);
+                map.put(ActivityType.EXAM, planProgress);
+            }
+
+            if (learning.getMode().equals(LearningMode.STUDY) && map.containsKey(ActivityType.STUDY)) {
+                PlanProgress planProgress = map.get(ActivityType.STUDY);
+                planProgress.addCompletedValue(1L);
+                map.put(ActivityType.STUDY, planProgress);
+            }
+
+            if (map.containsKey(ActivityType.PROBLEM)) {
+                PlanProgress planProgress = map.get(ActivityType.PROBLEM);
+                planProgress.addCompletedValue(learning.getSolvingCount());
+            }
+
+            if (map.containsKey(ActivityType.TIME)) {
+                PlanProgress planProgress = map.get(ActivityType.TIME);
+                planProgress.addCompletedValue(learning.getLearningTime());
+            }
+        });
+
+        return map.values().stream().toList();
+    }
+}

--- a/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/PlanRepository.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/PlanRepository.java
@@ -5,8 +5,10 @@ import com.jabiseo.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDate;
+import java.util.Optional;
 
 public interface PlanRepository extends JpaRepository<Plan, Long> {
 
     boolean existsByCertificateAndMemberAndEndAtAfter(Certificate certificate, Member member, LocalDate now);
+    Optional<Plan> findFirstByCertificateAndMember(Certificate certificate, Member member);
 }

--- a/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/PlanRepository.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/PlanRepository.java
@@ -1,0 +1,12 @@
+package com.jabiseo.plan.domain;
+
+import com.jabiseo.certificate.domain.Certificate;
+import com.jabiseo.member.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+
+public interface PlanRepository extends JpaRepository<Plan, Long> {
+
+    boolean existsByCertificateAndMemberAndEndAtAfter(Certificate certificate, Member member, LocalDate now);
+}

--- a/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/PlanService.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/PlanService.java
@@ -1,0 +1,31 @@
+package com.jabiseo.plan.domain;
+
+import com.jabiseo.member.domain.Member;
+import com.jabiseo.plan.exception.PlanBusinessException;
+import com.jabiseo.plan.exception.PlanErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PlanService {
+
+    private final PlanRepository planRepository;
+    private final PlanItemRepository planItemRepository;
+
+    public Plan savePlanAndItems(Plan plan, List<PlanItem> planItems) {
+        planItemRepository.saveAll(planItems);
+        return planRepository.save(plan);
+    }
+
+
+    public void checkInProgressPlan(Member member, LocalDate now){
+        if(planRepository.existsByCertificateAndMemberAndEndAtAfter(member.getCurrentCertificate(),member, now)){
+            throw new PlanBusinessException(PlanErrorCode.ALREADY_EXIST_PLAN);
+        }
+    }
+
+}

--- a/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/SundayStartWeeklyStrategy.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/SundayStartWeeklyStrategy.java
@@ -1,0 +1,61 @@
+package com.jabiseo.plan.domain;
+
+import org.springframework.stereotype.Component;
+
+import java.time.*;
+import java.time.temporal.TemporalAdjusters;
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class SundayStartWeeklyStrategy implements WeeklyDefineStrategy{
+
+    @Override
+    public List<WeekPeriod> getPeriodPerWeek(int year, int month) {
+        List<WeekPeriod> periods = new ArrayList<>();
+
+        YearMonth yearMonth = YearMonth.of(year, month);
+        LocalDate monthStartDate = yearMonth.atDay(1);
+        LocalDate monthEndDate = yearMonth.atEndOfMonth();
+
+        LocalDate startBoundary = monthStartDate.with(DayOfWeek.SUNDAY);
+
+        // 월의 첫 날이 일요일 이후일 경우 그 전 주의 일요일로 이동
+        if (monthStartDate.getDayOfWeek() != DayOfWeek.SUNDAY) {
+            startBoundary = startBoundary.minusWeeks(1);
+        }
+
+
+        // 마지막 날이 속한 주의 토요일로 이동
+        LocalDate endBoundary = monthEndDate.with(DayOfWeek.SATURDAY);
+
+
+        // 월의 마지막 날이 일요일인 경우 그 다음 주의 토요일로 이동
+        if (monthEndDate.getDayOfWeek() == DayOfWeek.SUNDAY) {
+            endBoundary = endBoundary.plusWeeks(1);
+        }
+
+        // 각각의 Period 를 계산.
+        LocalDate weekStart = startBoundary;
+        while (!weekStart.isAfter(endBoundary)) {
+            LocalDate weekEnd = weekStart.plusDays(6);
+
+            if (weekEnd.isAfter(monthEndDate)) {
+                weekEnd = monthEndDate;
+            }
+
+            periods.add(new WeekPeriod(weekStart, weekEnd));
+
+            weekStart = weekStart.plusWeeks(1);
+        }
+
+        return periods;
+    }
+
+    @Override
+    public WeekPeriod getCurrentWeekPeriod(LocalDate now) {
+        LocalDate start = now.with(TemporalAdjusters.previousOrSame(DayOfWeek.SUNDAY));
+        LocalDate end = now.with(TemporalAdjusters.nextOrSame(DayOfWeek.SATURDAY));
+        return new WeekPeriod(start, end);
+    }
+}

--- a/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/SundayStartWeeklyStrategy.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/SundayStartWeeklyStrategy.java
@@ -53,9 +53,9 @@ public class SundayStartWeeklyStrategy implements WeeklyDefineStrategy{
     }
 
     @Override
-    public WeekPeriod getCurrentWeekPeriod(LocalDate now) {
-        LocalDate start = now.with(TemporalAdjusters.previousOrSame(DayOfWeek.SUNDAY));
-        LocalDate end = now.with(TemporalAdjusters.nextOrSame(DayOfWeek.SATURDAY));
+    public WeekPeriod getWeekPeriod(LocalDate date) {
+        LocalDate start = date.with(TemporalAdjusters.previousOrSame(DayOfWeek.SUNDAY));
+        LocalDate end = date.with(TemporalAdjusters.nextOrSame(DayOfWeek.SATURDAY));
         return new WeekPeriod(start, end);
     }
 }

--- a/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/WeekPeriod.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/WeekPeriod.java
@@ -1,0 +1,17 @@
+package com.jabiseo.plan.domain;
+
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class WeekPeriod {
+
+    private LocalDate start;
+    private LocalDate end;
+
+    public WeekPeriod(LocalDate start, LocalDate end) {
+        this.start = start;
+        this.end = end;
+    }
+}

--- a/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/WeeklyDefineStrategy.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/WeeklyDefineStrategy.java
@@ -1,0 +1,11 @@
+package com.jabiseo.plan.domain;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface WeeklyDefineStrategy {
+
+    List<WeekPeriod> getPeriodPerWeek(int year, int month);
+
+    WeekPeriod getCurrentWeekPeriod(LocalDate now);
+}

--- a/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/WeeklyDefineStrategy.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/WeeklyDefineStrategy.java
@@ -7,5 +7,5 @@ public interface WeeklyDefineStrategy {
 
     List<WeekPeriod> getPeriodPerWeek(int year, int month);
 
-    WeekPeriod getCurrentWeekPeriod(LocalDate now);
+    WeekPeriod getWeekPeriod(LocalDate date);
 }

--- a/jabiseo-domain/src/main/java/com/jabiseo/plan/exception/PlanBusinessException.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/plan/exception/PlanBusinessException.java
@@ -1,0 +1,11 @@
+package com.jabiseo.plan.exception;
+
+import com.jabiseo.common.exception.BusinessException;
+import com.jabiseo.common.exception.ErrorCode;
+
+public class PlanBusinessException extends BusinessException {
+
+    public PlanBusinessException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/jabiseo-domain/src/main/java/com/jabiseo/plan/exception/PlanErrorCode.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/plan/exception/PlanErrorCode.java
@@ -1,0 +1,20 @@
+package com.jabiseo.plan.exception;
+
+import com.jabiseo.common.exception.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public enum PlanErrorCode implements ErrorCode {
+
+    ALREADY_EXIST_PLAN("이미 진행중인 플랜이 있습니다","PLAN_001", ErrorCode.CONFLICT);
+
+    PlanErrorCode(String message, String errorCode, int statusCode) {
+        this.message = message;
+        this.errorCode = errorCode;
+        this.statusCode = statusCode;
+    }
+
+    private final String message;
+    private final String errorCode;
+    private final int statusCode;
+}

--- a/jabiseo-domain/src/main/java/com/jabiseo/plan/exception/PlanErrorCode.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/plan/exception/PlanErrorCode.java
@@ -7,7 +7,8 @@ import lombok.Getter;
 public enum PlanErrorCode implements ErrorCode {
 
     ALREADY_EXIST_PLAN("이미 진행중인 플랜이 있습니다", "PLAN_001", ErrorCode.CONFLICT),
-    NOT_FOUND_PLAN("플랜을 찾을 수 없습니다", "PLAN_002", ErrorCode.NOT_FOUND);
+    NOT_FOUND_PLAN("플랜을 찾을 수 없습니다", "PLAN_002", ErrorCode.NOT_FOUND),
+    IS_NOT_OWNER("플랜 주인이 아닙니다", "PLAN_003", ErrorCode.FORBIDDEN);
 
     PlanErrorCode(String message, String errorCode, int statusCode) {
         this.message = message;

--- a/jabiseo-domain/src/main/java/com/jabiseo/plan/exception/PlanErrorCode.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/plan/exception/PlanErrorCode.java
@@ -6,7 +6,8 @@ import lombok.Getter;
 @Getter
 public enum PlanErrorCode implements ErrorCode {
 
-    ALREADY_EXIST_PLAN("이미 진행중인 플랜이 있습니다","PLAN_001", ErrorCode.CONFLICT);
+    ALREADY_EXIST_PLAN("이미 진행중인 플랜이 있습니다", "PLAN_001", ErrorCode.CONFLICT),
+    NOT_FOUND_PLAN("플랜을 찾을 수 없습니다", "PLAN_002", ErrorCode.NOT_FOUND);
 
     PlanErrorCode(String message, String errorCode, int statusCode) {
         this.message = message;

--- a/jabiseo-domain/src/test/java/com/jabiseo/plan/domain/PlanProgressServiceTest.java
+++ b/jabiseo-domain/src/test/java/com/jabiseo/plan/domain/PlanProgressServiceTest.java
@@ -6,7 +6,6 @@ import com.jabiseo.learning.dto.LearningWithSolvingCountQueryDto;
 import com.jabiseo.member.domain.Member;
 import fixture.MemberFixture;
 import fixture.PlanItemFixture;
-import fixture.PlanProgressFixture;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -62,7 +61,7 @@ class PlanProgressServiceTest {
         List<LearningWithSolvingCountQueryDto> queryDtos = Arrays.asList(new LearningWithSolvingCountQueryDto(LearningMode.EXAM, 10L, LocalDateTime.now(), 10L));
         WeekPeriod currentWeekPeriod = new WeekPeriod(LocalDate.now().withDayOfMonth(1), LocalDate.now().plusDays(6));
 
-        given(weeklyDefineStrategy.getCurrentWeekPeriod(LocalDate.now())).willReturn(currentWeekPeriod);
+        given(weeklyDefineStrategy.getWeekPeriod(LocalDate.now())).willReturn(currentWeekPeriod);
         given(learningRepository.findLearningWithSolvingCount(member, member.getCurrentCertificate(),
                 LocalDate.now(), LocalDate.now())).willReturn(queryDtos);
         given(learningRepository.findLearningWithSolvingCount(member, member.getCurrentCertificate(),
@@ -85,7 +84,7 @@ class PlanProgressServiceTest {
         );
         List<LearningWithSolvingCountQueryDto> queryDtos = Arrays.asList(new LearningWithSolvingCountQueryDto(LearningMode.EXAM, 10L, LocalDateTime.now(), 10L));
 
-        given(weeklyDefineStrategy.getCurrentWeekPeriod(LocalDate.now())).willReturn(new WeekPeriod(LocalDate.now(), LocalDate.now().plusDays(1)));
+        given(weeklyDefineStrategy.getWeekPeriod(LocalDate.now())).willReturn(new WeekPeriod(LocalDate.now(), LocalDate.now().plusDays(1)));
         given(learningRepository.findLearningWithSolvingCount(member, member.getCurrentCertificate(),
                 LocalDate.now(), LocalDate.now())).willReturn(queryDtos);
 

--- a/jabiseo-domain/src/test/java/com/jabiseo/plan/domain/PlanProgressServiceTest.java
+++ b/jabiseo-domain/src/test/java/com/jabiseo/plan/domain/PlanProgressServiceTest.java
@@ -1,0 +1,157 @@
+package com.jabiseo.plan.domain;
+
+import com.jabiseo.learning.domain.LearningMode;
+import com.jabiseo.learning.domain.LearningRepository;
+import com.jabiseo.learning.dto.LearningWithSolvingCountQueryDto;
+import com.jabiseo.member.domain.Member;
+import fixture.MemberFixture;
+import fixture.PlanItemFixture;
+import fixture.PlanProgressFixture;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static fixture.PlanProgressFixture.createPlanProgress;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class PlanProgressServiceTest {
+
+    @InjectMocks
+    private PlanProgressService planProgressService;
+    @Mock
+    private PlanProgressRepository planProgressRepository;
+    @Mock
+    private LearningRepository learningRepository;
+
+    @Mock
+    private WeeklyDefineStrategy weeklyDefineStrategy;
+
+    private Member member;
+    private WeekPeriod weekPeriod;
+
+    @BeforeEach
+    void setUp() {
+        member = MemberFixture.createMember();
+    }
+
+    @Test
+    @DisplayName("정상 동작 테스트, 주간  일간에 맞게 2번 호출한다")
+    void successCallSaveAllTwo() {
+        //given
+        List<PlanItem> planItems = Arrays.asList(
+                PlanItemFixture.createPlanItem(ActivityType.EXAM, GoalType.DAILY),
+                PlanItemFixture.createPlanItem(ActivityType.STUDY, GoalType.DAILY),
+                PlanItemFixture.createPlanItem(ActivityType.STUDY, GoalType.WEEKLY),
+                PlanItemFixture.createPlanItem(ActivityType.PROBLEM, GoalType.WEEKLY)
+        );
+        List<LearningWithSolvingCountQueryDto> queryDtos = Arrays.asList(new LearningWithSolvingCountQueryDto(LearningMode.EXAM, 10L, LocalDateTime.now(), 10L));
+        WeekPeriod currentWeekPeriod = new WeekPeriod(LocalDate.now().withDayOfMonth(1), LocalDate.now().plusDays(6));
+
+        given(weeklyDefineStrategy.getCurrentWeekPeriod(LocalDate.now())).willReturn(currentWeekPeriod);
+        given(learningRepository.findLearningWithSolvingCount(member, member.getCurrentCertificate(),
+                LocalDate.now(), LocalDate.now())).willReturn(queryDtos);
+        given(learningRepository.findLearningWithSolvingCount(member, member.getCurrentCertificate(),
+                currentWeekPeriod.getStart(), currentWeekPeriod.getEnd())).willReturn(queryDtos);
+
+        //when
+        planProgressService.createCurrentPlanProgress(member, planItems);
+
+        //then
+        verify(planProgressRepository, times(2)).saveAll(any());
+    }
+
+    @Test
+    @DisplayName("없는 goalType에 대해 DB 로직 호출을 하지 않는다. ")
+    void callSaveAllOne() {
+        //given
+        List<PlanItem> planItems = Arrays.asList(
+                PlanItemFixture.createPlanItem(ActivityType.EXAM, GoalType.DAILY),
+                PlanItemFixture.createPlanItem(ActivityType.STUDY, GoalType.DAILY)
+        );
+        List<LearningWithSolvingCountQueryDto> queryDtos = Arrays.asList(new LearningWithSolvingCountQueryDto(LearningMode.EXAM, 10L, LocalDateTime.now(), 10L));
+
+        given(weeklyDefineStrategy.getCurrentWeekPeriod(LocalDate.now())).willReturn(new WeekPeriod(LocalDate.now(), LocalDate.now().plusDays(1)));
+        given(learningRepository.findLearningWithSolvingCount(member, member.getCurrentCertificate(),
+                LocalDate.now(), LocalDate.now())).willReturn(queryDtos);
+
+        //when
+        planProgressService.createCurrentPlanProgress(member, planItems);
+
+        //then
+        verify(planProgressRepository, times(1)).saveAll(any());
+    }
+
+    @Test
+    @DisplayName("calculateProgress 메소드 progress 계산 로직 테스트")
+    void calculateProgressTest() {
+        //given
+        List<PlanProgress> planProgresses = Arrays.asList(
+                createPlanProgress(LocalDate.now(), GoalType.DAILY, ActivityType.EXAM),
+                createPlanProgress(LocalDate.now(), GoalType.DAILY, ActivityType.STUDY),
+                createPlanProgress(LocalDate.now(), GoalType.DAILY, ActivityType.PROBLEM),
+                createPlanProgress(LocalDate.now(), GoalType.DAILY, ActivityType.TIME)
+        );
+        List<LearningWithSolvingCountQueryDto> datas = dummyDatas();
+
+
+        //when
+        List<PlanProgress> result = planProgressService.calculateProgress(planProgresses, datas);
+
+        //then
+        result.forEach((planProgress -> {
+            long expectedValue = -1;
+            if (planProgress.getActivityType().equals(ActivityType.EXAM)) {
+                expectedValue = datas.stream()
+                        .filter(pi -> pi.getMode().equals(LearningMode.EXAM))
+                        .count();
+            }
+            if (planProgress.getActivityType().equals(ActivityType.STUDY)) {
+                expectedValue = datas.stream()
+                        .filter(pi -> pi.getMode().equals(LearningMode.STUDY))
+                        .count();
+            }
+            if (planProgress.getActivityType().equals(ActivityType.PROBLEM)) {
+                expectedValue = datas.stream()
+                        .mapToLong(LearningWithSolvingCountQueryDto::getSolvingCount).sum();
+            }
+            if (planProgress.getActivityType().equals(ActivityType.TIME)) {
+                expectedValue = datas.stream()
+                        .mapToLong(LearningWithSolvingCountQueryDto::getLearningTime).sum();
+            }
+
+            Assertions.assertThat(planProgress.getCompletedValue()).isEqualTo(expectedValue);
+        }));
+
+    }
+
+    private List<LearningWithSolvingCountQueryDto> dummyDatas() {
+        List<LearningWithSolvingCountQueryDto> datas = new ArrayList<>();
+        LocalDateTime now = LocalDateTime.now();
+        datas.add(new LearningWithSolvingCountQueryDto(LearningMode.EXAM, 5000L, now, 1L));
+        datas.add(new LearningWithSolvingCountQueryDto(LearningMode.EXAM, 5000L, now, 2L));
+        datas.add(new LearningWithSolvingCountQueryDto(LearningMode.EXAM, 5000L, now, 3L));
+        datas.add(new LearningWithSolvingCountQueryDto(LearningMode.EXAM, 5000L, now, 4L));
+        datas.add(new LearningWithSolvingCountQueryDto(LearningMode.STUDY, 5000L, now, 5L));
+        datas.add(new LearningWithSolvingCountQueryDto(LearningMode.STUDY, 5000L, now, 6L));
+        datas.add(new LearningWithSolvingCountQueryDto(LearningMode.STUDY, 5000L, now, 7L));
+        datas.add(new LearningWithSolvingCountQueryDto(LearningMode.STUDY, 5000L, now, 8L));
+        datas.add(new LearningWithSolvingCountQueryDto(LearningMode.STUDY, 5000L, now, 9L));
+        datas.add(new LearningWithSolvingCountQueryDto(LearningMode.EXAM, 5000L, now, 10L));
+        return datas;
+    }
+}

--- a/jabiseo-domain/src/test/java/com/jabiseo/plan/domain/PlanServiceTest.java
+++ b/jabiseo-domain/src/test/java/com/jabiseo/plan/domain/PlanServiceTest.java
@@ -1,0 +1,49 @@
+package com.jabiseo.plan.domain;
+
+import com.jabiseo.member.domain.Member;
+import com.jabiseo.plan.exception.PlanBusinessException;
+import fixture.MemberFixture;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class PlanServiceTest {
+
+    @InjectMocks
+    private PlanService planService;
+
+    @Mock
+    private PlanRepository planRepository;
+
+    @Mock
+    private PlanItemRepository planItemRepository;
+
+    @Test
+    @DisplayName("이미 진행중인 플랜이 있는 경우 예외를 반환한다")
+    void existInProgressPlanThrownException() {
+        //given
+        Member member = MemberFixture.createMember();
+
+        given(planRepository.existsByCertificateAndMemberAndEndAtAfter(member.getCurrentCertificate(), member, LocalDate.now()))
+                .willReturn(true);
+        //when then
+        Assertions.assertThatThrownBy(()->planService.checkInProgressPlan(member, LocalDate.now()))
+                .isInstanceOf(PlanBusinessException.class);
+
+
+    }
+
+}

--- a/jabiseo-domain/src/test/java/com/jabiseo/plan/domain/SundayStartWeeklyStrategyTest.java
+++ b/jabiseo-domain/src/test/java/com/jabiseo/plan/domain/SundayStartWeeklyStrategyTest.java
@@ -1,0 +1,43 @@
+package com.jabiseo.plan.domain;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("일요일시작 주간 정의 클래스 테스트")
+class SundayStartWeeklyStrategyTest {
+
+    WeeklyDefineStrategy weeklyDefineStrategy;
+
+    @BeforeEach
+    void setup() {
+        weeklyDefineStrategy = new SundayStartWeeklyStrategy();
+    }
+
+
+    @ParameterizedTest
+    @DisplayName("입력 날짜를 기준으로 주간 정의의 시작, 종료 값을 리턴한다")
+    @ValueSource(strings = {"2024-09-01", "2024-09-09", "2024-09-17", "2024-09-25", "2024-10-03", "2024-10-11", "2024-10-12"})
+    void getCurrentWeekPeriod(LocalDate now) throws Exception {
+        //given
+        DayOfWeek dayOfWeek = now.getDayOfWeek();
+
+        // getValue는 월 1 ~ 일 7이다. % 7 연산을 해 일요일인 경우 그 날 - 0 이 성립하도록 start 테스트 코드 구성
+        LocalDate startOfWeek = now.minusDays(dayOfWeek.getValue() % 7);
+        LocalDate endOfWeek = startOfWeek.plusDays(6);
+
+        //when
+        WeekPeriod currentWeekPeriod = weeklyDefineStrategy.getCurrentWeekPeriod(now);
+
+        //then
+        assertThat(currentWeekPeriod.getStart()).isEqualTo(startOfWeek);
+        assertThat(currentWeekPeriod.getEnd()).isEqualTo(endOfWeek);
+    }
+
+}

--- a/jabiseo-domain/src/test/java/com/jabiseo/plan/domain/SundayStartWeeklyStrategyTest.java
+++ b/jabiseo-domain/src/test/java/com/jabiseo/plan/domain/SundayStartWeeklyStrategyTest.java
@@ -24,7 +24,7 @@ class SundayStartWeeklyStrategyTest {
     @ParameterizedTest
     @DisplayName("입력 날짜를 기준으로 주간 정의의 시작, 종료 값을 리턴한다")
     @ValueSource(strings = {"2024-09-01", "2024-09-09", "2024-09-17", "2024-09-25", "2024-10-03", "2024-10-11", "2024-10-12"})
-    void getCurrentWeekPeriod(LocalDate now) throws Exception {
+    void getWeekPeriod(LocalDate now) throws Exception {
         //given
         DayOfWeek dayOfWeek = now.getDayOfWeek();
 
@@ -33,7 +33,7 @@ class SundayStartWeeklyStrategyTest {
         LocalDate endOfWeek = startOfWeek.plusDays(6);
 
         //when
-        WeekPeriod currentWeekPeriod = weeklyDefineStrategy.getCurrentWeekPeriod(now);
+        WeekPeriod currentWeekPeriod = weeklyDefineStrategy.getWeekPeriod(now);
 
         //then
         assertThat(currentWeekPeriod.getStart()).isEqualTo(startOfWeek);

--- a/jabiseo-domain/src/testFixtures/java/fixture/LearningFixture.java
+++ b/jabiseo-domain/src/testFixtures/java/fixture/LearningFixture.java
@@ -3,12 +3,13 @@ package fixture;
 import com.jabiseo.certificate.domain.Certificate;
 import com.jabiseo.learning.domain.Learning;
 import com.jabiseo.learning.domain.LearningMode;
+import com.jabiseo.member.domain.Member;
 import org.springframework.test.util.ReflectionTestUtils;
 
 public class LearningFixture {
 
     public static Learning createLearning(Long id, Certificate certificate) {
-        Learning learning = Learning.of(LearningMode.EXAM, 123L, certificate);
+        Learning learning = Learning.of(LearningMode.EXAM, 123L, certificate, MemberFixture.createMember());
         ReflectionTestUtils.setField(learning, "id", id);
         return learning;
     }

--- a/jabiseo-domain/src/testFixtures/java/fixture/PlanFixture.java
+++ b/jabiseo-domain/src/testFixtures/java/fixture/PlanFixture.java
@@ -1,0 +1,16 @@
+package fixture;
+
+import com.jabiseo.member.domain.Member;
+import com.jabiseo.plan.domain.Plan;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+
+public class PlanFixture {
+    public static Plan createPlan(Member member, Long planId) {
+        Plan plan = Plan.create(member, LocalDate.now());
+
+        ReflectionTestUtils.setField(plan, "id", planId);
+        return plan;
+    }
+}

--- a/jabiseo-domain/src/testFixtures/java/fixture/PlanItemFixture.java
+++ b/jabiseo-domain/src/testFixtures/java/fixture/PlanItemFixture.java
@@ -1,0 +1,17 @@
+package fixture;
+
+import com.jabiseo.plan.domain.ActivityType;
+import com.jabiseo.plan.domain.GoalType;
+import com.jabiseo.plan.domain.Plan;
+import com.jabiseo.plan.domain.PlanItem;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class PlanItemFixture {
+
+    public static PlanItem createPlanItem(ActivityType activityType, GoalType goalType) {
+        Plan plan = PlanFixture.createPlan(MemberFixture.createMember(), 1L);
+        PlanItem planItem = new PlanItem(plan, activityType, goalType, 0);
+        ReflectionTestUtils.setField(planItem, "id", 1L);
+        return planItem;
+    }
+}

--- a/jabiseo-domain/src/testFixtures/java/fixture/PlanProgressFixture.java
+++ b/jabiseo-domain/src/testFixtures/java/fixture/PlanProgressFixture.java
@@ -1,0 +1,24 @@
+package fixture;
+
+import com.jabiseo.plan.domain.ActivityType;
+import com.jabiseo.plan.domain.GoalType;
+import com.jabiseo.plan.domain.PlanProgress;
+
+import java.time.LocalDate;
+
+public class PlanProgressFixture {
+
+    public static PlanProgress createPlanProgress(LocalDate date, GoalType goalType, ActivityType activityType) {
+        PlanProgress planProgress = PlanProgress.builder()
+                .progressDate(date)
+                .targetValue(10)
+                .goalType(goalType)
+                .activityType(activityType)
+                .completedValue(0L)
+                .plan(PlanFixture.createPlan(MemberFixture.createMember(), 1L))
+                .build();
+
+        return planProgress;
+    }
+
+}


### PR DESCRIPTION
## PR 변경된 내용
- Plan Entity 구성
- 결과 제출 후 PlanProgress 생성
- 플랜 생성, 조회 로직 구현

### Plan Entity 구성
- 학습 플랜의 요구사항에 맞게 Entity 구성 (https://github.com/orgs/Jabiseo/discussions/64) 양이 많아 따로 올림
- Learning에 Member가 없던 부분 추가


### 결과 제출 후 PlanProgress 생성
- PlanProgressService에 updateProgress() 메소드 호출
- (1) 진행중인 플랜이 있는지 확인
- (2) PlanProgress가 DB에 있는지 확인, 없으면 생성해줘야 함(문제를 제출했으면 날짜범위(일간,주간)에 0인 값이라도 DB에 있어야 한다)
- (3). 이후 결과 제출 데이터 기반으로 PlanProgress 업데이트


### 플랜 생성
- (1): 진행중인 자격증/ 플랜이 있는지 확인
- (2): DB에 저장후 현재 문제풀이 기록(Learning와 ProblemsSolving) 기반으로 현재날짜(일간은 오늘, 주간은 주 범위)에 데이터가 있다면 PlanProgress을 생성한다.
- 추가적으로 Learning과 ProblemSolving 정보를 가져오는 쿼리는 일간/주간에 따라 일단 2개 분기로 처리해서 날림


### 플랜 조회
- PlanProgress 정보를 읽어와서 일간 / 주간에 따라 리턴함.
- 주간같은 경우 달의 첫날, 마지막 날이 아닌 첫주 마지막 주는 그 전달, 그 이후 달의 날짜 범위가 포함될 수 있다.
- 해당 부분을 한 곳에서 관리하기 위해 SundayStratWeeklyStrategy라는 클래스에서 날짜 관련 메소드를 제공함.

### 기타
- Plan쪽은 대부분 Service라는 클래스를 생성해서 로직을 분리함
- 플랜 수정은 다음 PR에 진행 예정( 기업 지원 이슈 )

## 참조
Closes #56 
