### PR TITLE
Feat(Plan): 플랜 수정, 삭제 로직 구현

### DIFF
--- a/jabiseo-api/src/main/java/com/jabiseo/plan/application/usecase/CreatePlanUseCase.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/plan/application/usecase/CreatePlanUseCase.java
@@ -23,7 +23,7 @@ public class CreatePlanUseCase {
     public Long execute(Long memberId, CreatePlanRequest request) {
         Member member = memberRepository.getReferenceById(memberId);
         member.validateCurrentCertificate();
-        planService.checkInProgressPlan(member, LocalDate.now());
+        planService.checkInProgressPlan(member);
 
         Plan plan = Plan.create(member, request.endAt());
         List<PlanItem> planItems = request.toPlanItems(plan);

--- a/jabiseo-api/src/main/java/com/jabiseo/plan/application/usecase/DeletePlanUseCase.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/plan/application/usecase/DeletePlanUseCase.java
@@ -1,0 +1,28 @@
+package com.jabiseo.plan.application.usecase;
+
+import com.jabiseo.plan.domain.Plan;
+import com.jabiseo.plan.domain.PlanRepository;
+import com.jabiseo.plan.domain.PlanService;
+import com.jabiseo.plan.exception.PlanBusinessException;
+import com.jabiseo.plan.exception.PlanErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class DeletePlanUseCase {
+
+    private final PlanService planService;
+    private final PlanRepository planRepository;
+
+    public void execute(Long planId, Long memberId) {
+        Plan plan = planRepository.findById(planId)
+                .orElseThrow(() -> new PlanBusinessException(PlanErrorCode.NOT_FOUND_PLAN));
+
+        plan.checkOwner(memberId);
+
+        planService.removePlan(plan);
+    }
+}

--- a/jabiseo-api/src/main/java/com/jabiseo/plan/application/usecase/ModifyPlanUseCase.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/plan/application/usecase/ModifyPlanUseCase.java
@@ -1,0 +1,51 @@
+package com.jabiseo.plan.application.usecase;
+
+import com.jabiseo.member.domain.Member;
+import com.jabiseo.member.domain.MemberRepository;
+import com.jabiseo.plan.domain.*;
+import com.jabiseo.plan.dto.ModifyPlanRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ModifyPlanUseCase {
+
+    private final PlanService planService;
+    private final PlanProgressService planProgressService;
+    private final MemberRepository memberRepository;
+
+    public void execute(Long planId, Long memberId, ModifyPlanRequest request) {
+        Plan plan = planService.getPlanWithItems(planId);
+        Member member = memberRepository.getReferenceById(memberId);
+        plan.checkOwner(memberId);
+
+        plan.modifyEndDay(request.endAt());
+
+        // 새로운 아이템은 추가한다.
+        List<PlanItem> requestDailyPlanItems = request.getDailyPlanItems(plan);
+        List<PlanItem> requestWeeklyPlanItems = request.getWeeklyPlanItems(plan);
+
+        List<PlanItem> newItems = plan.getNewItems(requestDailyPlanItems, requestWeeklyPlanItems);
+        planProgressService.createCurrentPlanProgress(member, newItems);
+
+        List<PlanItem> existItems = plan.getExistItems(requestDailyPlanItems, requestWeeklyPlanItems);
+        planProgressService.modifyCurrentPlanProgress(plan, filteringGoalType(existItems, GoalType.DAILY), filteringGoalType(existItems, GoalType.WEEKLY));
+
+        List<PlanItem> deletedItems = plan.getDeletedItems(requestDailyPlanItems, requestWeeklyPlanItems);
+        planProgressService.removeCurrentPlanProgress(plan, filteringGoalType(deletedItems, GoalType.DAILY), filteringGoalType(deletedItems, GoalType.WEEKLY));
+
+        // Plan 객체의 정합성을 유지(DB 저장)
+        plan.modifyPlanItems(requestDailyPlanItems, requestWeeklyPlanItems);
+    }
+
+    private List<PlanItem> filteringGoalType(List<PlanItem> planItems, GoalType goalType) {
+        return planItems.stream()
+                .filter((planItem) -> planItem.getGoalType().equals(goalType))
+                .toList();
+    }
+}

--- a/jabiseo-api/src/main/java/com/jabiseo/plan/application/usecase/SearchPlanCalenderUseCase.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/plan/application/usecase/SearchPlanCalenderUseCase.java
@@ -49,7 +49,7 @@ public class SearchPlanCalenderUseCase {
                 .collect(Collectors.groupingBy(PlanProgress::getProgressDate, Collectors.toList()));
 
         return map.entrySet().stream()
-                .sorted()
+                .sorted(Map.Entry.comparingByKey())
                 .map(entry -> {
                     List<PlanProgressResponse> list = entry.getValue()
                             .stream()

--- a/jabiseo-api/src/main/java/com/jabiseo/plan/controller/PlanController.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/plan/controller/PlanController.java
@@ -4,9 +4,11 @@ import com.jabiseo.config.auth.AuthMember;
 import com.jabiseo.config.auth.AuthenticatedMember;
 import com.jabiseo.plan.application.usecase.CreatePlanUseCase;
 import com.jabiseo.plan.application.usecase.FindActivePlanUseCase;
+import com.jabiseo.plan.application.usecase.ModifyPlanUseCase;
 import com.jabiseo.plan.application.usecase.SearchPlanCalenderUseCase;
 import com.jabiseo.plan.dto.ActivePlanResponse;
 import com.jabiseo.plan.dto.CreatePlanRequest;
+import com.jabiseo.plan.dto.ModifyPlanRequest;
 import com.jabiseo.plan.dto.calender.PlanCalenderSearchResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +26,7 @@ public class PlanController {
     private final CreatePlanUseCase createPlanUseCase;
     private final FindActivePlanUseCase findActivePlanUseCase;
     private final SearchPlanCalenderUseCase searchPlanCalenderUseCase;
+    private final ModifyPlanUseCase modifyPlanUseCase;
 
     @PostMapping
     public ResponseEntity<Void> create(@Valid @RequestBody CreatePlanRequest request, @AuthenticatedMember AuthMember member) {
@@ -51,5 +54,14 @@ public class PlanController {
                                                                       @RequestParam(name = "month") int month) {
         PlanCalenderSearchResponse result = searchPlanCalenderUseCase.execute(member.getMemberId(), planId, year, month);
         return ResponseEntity.ok(result);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Void> update(@AuthenticatedMember AuthMember member,
+                                       @PathVariable("id") Long planId,
+                                       @RequestBody ModifyPlanRequest request){
+        modifyPlanUseCase.execute(planId, member.getMemberId(), request);
+
+        return ResponseEntity.noContent().build();
     }
 }

--- a/jabiseo-api/src/main/java/com/jabiseo/plan/controller/PlanController.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/plan/controller/PlanController.java
@@ -2,10 +2,7 @@ package com.jabiseo.plan.controller;
 
 import com.jabiseo.config.auth.AuthMember;
 import com.jabiseo.config.auth.AuthenticatedMember;
-import com.jabiseo.plan.application.usecase.CreatePlanUseCase;
-import com.jabiseo.plan.application.usecase.FindActivePlanUseCase;
-import com.jabiseo.plan.application.usecase.ModifyPlanUseCase;
-import com.jabiseo.plan.application.usecase.SearchPlanCalenderUseCase;
+import com.jabiseo.plan.application.usecase.*;
 import com.jabiseo.plan.dto.ActivePlanResponse;
 import com.jabiseo.plan.dto.CreatePlanRequest;
 import com.jabiseo.plan.dto.ModifyPlanRequest;
@@ -27,6 +24,7 @@ public class PlanController {
     private final FindActivePlanUseCase findActivePlanUseCase;
     private final SearchPlanCalenderUseCase searchPlanCalenderUseCase;
     private final ModifyPlanUseCase modifyPlanUseCase;
+    private final DeletePlanUseCase deletePlanUseCase;
 
     @PostMapping
     public ResponseEntity<Void> create(@Valid @RequestBody CreatePlanRequest request, @AuthenticatedMember AuthMember member) {
@@ -59,9 +57,17 @@ public class PlanController {
     @PutMapping("/{id}")
     public ResponseEntity<Void> update(@AuthenticatedMember AuthMember member,
                                        @PathVariable("id") Long planId,
-                                       @RequestBody ModifyPlanRequest request){
+                                       @RequestBody ModifyPlanRequest request) {
         modifyPlanUseCase.execute(planId, member.getMemberId(), request);
 
+        return ResponseEntity.noContent().build();
+    }
+
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@AuthenticatedMember AuthMember member,
+                                       @PathVariable("id") Long planId) {
+        deletePlanUseCase.execute(planId, member.getMemberId());
         return ResponseEntity.noContent().build();
     }
 }

--- a/jabiseo-api/src/main/java/com/jabiseo/plan/dto/ActivePlanResponse.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/plan/dto/ActivePlanResponse.java
@@ -13,6 +13,7 @@ public record ActivePlanResponse(
         CertificateResponse certificate,
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
         LocalDate endAt,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
         LocalDate createdAt,
         List<PlanItemResponse> dailyPlanItems,
         List<PlanItemResponse> weeklyPlanItems

--- a/jabiseo-api/src/main/java/com/jabiseo/plan/dto/ModifyPlanRequest.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/plan/dto/ModifyPlanRequest.java
@@ -1,0 +1,37 @@
+package com.jabiseo.plan.dto;
+
+import com.jabiseo.plan.domain.ActivityType;
+import com.jabiseo.plan.domain.GoalType;
+import com.jabiseo.plan.domain.Plan;
+import com.jabiseo.plan.domain.PlanItem;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+public record ModifyPlanRequest(
+        @NotNull @Future
+        LocalDate endAt,
+
+        @NotNull @Valid
+        List<PlanItemRequest> dailyPlan,
+
+        @NotNull @Valid
+        List<PlanItemRequest> weeklyPlan
+) {
+
+    public List<PlanItem> getDailyPlanItems(Plan plan) {
+        List<PlanItem> planItems = new ArrayList<>();
+        this.dailyPlan.forEach((p) -> planItems.add(new PlanItem(plan, ActivityType.valueOf(p.activityType()), GoalType.DAILY, p.targetValue())));
+        return planItems;
+    }
+
+    public List<PlanItem> getWeeklyPlanItems(Plan plan) {
+        List<PlanItem> planItems = new ArrayList<>();
+        this.weeklyPlan.forEach((p) -> planItems.add(new PlanItem(plan, ActivityType.valueOf(p.activityType()), GoalType.WEEKLY, p.targetValue())));
+        return planItems;
+    }
+}

--- a/jabiseo-api/src/main/java/com/jabiseo/plan/dto/ModifyPlanRequest.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/plan/dto/ModifyPlanRequest.java
@@ -24,14 +24,10 @@ public record ModifyPlanRequest(
 ) {
 
     public List<PlanItem> getDailyPlanItems(Plan plan) {
-        List<PlanItem> planItems = new ArrayList<>();
-        this.dailyPlan.forEach((p) -> planItems.add(new PlanItem(plan, ActivityType.valueOf(p.activityType()), GoalType.DAILY, p.targetValue())));
-        return planItems;
+        return dailyPlan.stream().map((item) -> new PlanItem(plan, ActivityType.valueOf(item.activityType()), GoalType.DAILY, item.targetValue())).toList();
     }
 
     public List<PlanItem> getWeeklyPlanItems(Plan plan) {
-        List<PlanItem> planItems = new ArrayList<>();
-        this.weeklyPlan.forEach((p) -> planItems.add(new PlanItem(plan, ActivityType.valueOf(p.activityType()), GoalType.WEEKLY, p.targetValue())));
-        return planItems;
+        return weeklyPlan.stream().map((item) -> new PlanItem(plan, ActivityType.valueOf(item.activityType()), GoalType.WEEKLY, item.targetValue())).toList();
     }
 }

--- a/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/PlanItem.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/PlanItem.java
@@ -55,4 +55,19 @@ public class PlanItem {
                 .completedValue(0L)
                 .build();
     }
+
+    public void updateTargetValue(Integer targetValue) {
+        this.targetValue = targetValue;
+    }
+
+
+    @Override
+    public String toString() {
+        return "PlanItem{" +
+                "targetValue=" + targetValue +
+                ", goalType=" + goalType +
+                ", activityType=" + activityType +
+                ", id=" + id +
+                '}';
+    }
 }

--- a/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/PlanItem.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/PlanItem.java
@@ -60,14 +60,4 @@ public class PlanItem {
         this.targetValue = targetValue;
     }
 
-
-    @Override
-    public String toString() {
-        return "PlanItem{" +
-                "targetValue=" + targetValue +
-                ", goalType=" + goalType +
-                ", activityType=" + activityType +
-                ", id=" + id +
-                '}';
-    }
 }

--- a/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/PlanProgress.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/PlanProgress.java
@@ -56,4 +56,8 @@ public class PlanProgress {
     public void addCompletedValue(Long add) {
         this.completedValue += add;
     }
+
+    public void updateTargetValue(Integer value) {
+        this.targetValue = value;
+    }
 }

--- a/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/PlanProgressRepository.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/PlanProgressRepository.java
@@ -9,5 +9,5 @@ public interface PlanProgressRepository extends JpaRepository<PlanProgress, Long
 
     List<PlanProgress> findAllByPlanAndProgressDateBetweenOrderByProgressDate(Plan plan, LocalDate start, LocalDate end);
 
-    List<PlanProgress> findAllByProgressDateBetweenAndGoalType(LocalDate start, LocalDate end, GoalType goalType);
+    List<PlanProgress> findAllByPlanAndProgressDateBetweenAndGoalType(Plan plan, LocalDate start, LocalDate end, GoalType goalType);
 }

--- a/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/PlanProgressRepository.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/PlanProgressRepository.java
@@ -1,6 +1,8 @@
 package com.jabiseo.plan.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -10,4 +12,8 @@ public interface PlanProgressRepository extends JpaRepository<PlanProgress, Long
     List<PlanProgress> findAllByPlanAndProgressDateBetweenOrderByProgressDate(Plan plan, LocalDate start, LocalDate end);
 
     List<PlanProgress> findAllByPlanAndProgressDateBetweenAndGoalType(Plan plan, LocalDate start, LocalDate end, GoalType goalType);
+
+    @Modifying
+    @Query("DELETE FROM PlanProgress pp WHERE pp.plan.id = :planId")
+    void deleteByPlanId(Long planId);
 }

--- a/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/PlanRepository.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/PlanRepository.java
@@ -6,12 +6,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.time.LocalDate;
 import java.util.Optional;
 
 public interface PlanRepository extends JpaRepository<Plan, Long> {
 
-    boolean existsByCertificateAndMemberAndEndAtAfter(Certificate certificate, Member member, LocalDate now);
+    boolean existsByCertificateAndMember(Certificate certificate, Member member);
     Optional<Plan> findFirstByCertificateAndMember(Certificate certificate, Member member);
 
     @Query("SELECT p FROM Plan p JOIN FETCH p.planItems WHERE p.id = :planId")

--- a/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/PlanRepository.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/PlanRepository.java
@@ -3,6 +3,8 @@ package com.jabiseo.plan.domain;
 import com.jabiseo.certificate.domain.Certificate;
 import com.jabiseo.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.util.Optional;
@@ -11,4 +13,8 @@ public interface PlanRepository extends JpaRepository<Plan, Long> {
 
     boolean existsByCertificateAndMemberAndEndAtAfter(Certificate certificate, Member member, LocalDate now);
     Optional<Plan> findFirstByCertificateAndMember(Certificate certificate, Member member);
+
+    @Query("SELECT p FROM Plan p JOIN FETCH p.planItems WHERE p.id = :planId")
+    Optional<Plan> findPlanWithItemsById(@Param("planId") Long planId);
+
 }

--- a/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/PlanService.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/PlanService.java
@@ -16,14 +16,19 @@ public class PlanService {
     private final PlanRepository planRepository;
     private final PlanItemRepository planItemRepository;
 
+    public Plan getPlanWithItems(Long planId) {
+        return planRepository.findPlanWithItemsById(planId)
+                .orElseThrow(() -> new PlanBusinessException(PlanErrorCode.NOT_FOUND_PLAN));
+    }
+
     public Plan savePlanAndItems(Plan plan, List<PlanItem> planItems) {
         planItemRepository.saveAll(planItems);
         return planRepository.save(plan);
     }
 
 
-    public void checkInProgressPlan(Member member, LocalDate now){
-        if(planRepository.existsByCertificateAndMemberAndEndAtAfter(member.getCurrentCertificate(),member, now)){
+    public void checkInProgressPlan(Member member, LocalDate now) {
+        if (planRepository.existsByCertificateAndMemberAndEndAtAfter(member.getCurrentCertificate(), member, now)) {
             throw new PlanBusinessException(PlanErrorCode.ALREADY_EXIST_PLAN);
         }
     }

--- a/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/PlanService.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/PlanService.java
@@ -6,7 +6,6 @@ import com.jabiseo.plan.exception.PlanErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDate;
 import java.util.List;
 
 @Service
@@ -28,8 +27,8 @@ public class PlanService {
     }
 
 
-    public void checkInProgressPlan(Member member, LocalDate now) {
-        if (planRepository.existsByCertificateAndMemberAndEndAtAfter(member.getCurrentCertificate(), member, now)) {
+    public void checkInProgressPlan(Member member) {
+        if (planRepository.existsByCertificateAndMember(member.getCurrentCertificate(), member)) {
             throw new PlanBusinessException(PlanErrorCode.ALREADY_EXIST_PLAN);
         }
     }

--- a/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/PlanService.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/PlanService.java
@@ -15,6 +15,7 @@ public class PlanService {
 
     private final PlanRepository planRepository;
     private final PlanItemRepository planItemRepository;
+    private final PlanProgressRepository planProgressRepository;
 
     public Plan getPlanWithItems(Long planId) {
         return planRepository.findPlanWithItemsById(planId)
@@ -31,6 +32,11 @@ public class PlanService {
         if (planRepository.existsByCertificateAndMemberAndEndAtAfter(member.getCurrentCertificate(), member, now)) {
             throw new PlanBusinessException(PlanErrorCode.ALREADY_EXIST_PLAN);
         }
+    }
+
+    public void removePlan(Plan plan){
+        planRepository.delete(plan); // cascade 설정으로 다 삭제가 된다
+        planProgressRepository.deleteByPlanId(plan.getId()); // plan progress를 삭제한다.
     }
 
 }

--- a/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/PlanService.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/plan/domain/PlanService.java
@@ -34,7 +34,7 @@ public class PlanService {
     }
 
     public void removePlan(Plan plan){
-        planRepository.delete(plan); // cascade 설정으로 다 삭제가 된다
+        planRepository.delete(plan); // cascade 설정으로 가지고 있는 planItem 들도 모두 삭제 된다
         planProgressRepository.deleteByPlanId(plan.getId()); // plan progress를 삭제한다.
     }
 

--- a/jabiseo-domain/src/test/java/com/jabiseo/plan/domain/PlanServiceTest.java
+++ b/jabiseo-domain/src/test/java/com/jabiseo/plan/domain/PlanServiceTest.java
@@ -37,10 +37,10 @@ class PlanServiceTest {
         //given
         Member member = MemberFixture.createMember();
 
-        given(planRepository.existsByCertificateAndMemberAndEndAtAfter(member.getCurrentCertificate(), member, LocalDate.now()))
+        given(planRepository.existsByCertificateAndMember(member.getCurrentCertificate(), member))
                 .willReturn(true);
         //when then
-        Assertions.assertThatThrownBy(()->planService.checkInProgressPlan(member, LocalDate.now()))
+        Assertions.assertThatThrownBy(()->planService.checkInProgressPlan(member))
                 .isInstanceOf(PlanBusinessException.class);
 
 

--- a/jabiseo-domain/src/test/java/com/jabiseo/plan/domain/PlanTest.java
+++ b/jabiseo-domain/src/test/java/com/jabiseo/plan/domain/PlanTest.java
@@ -1,0 +1,193 @@
+package com.jabiseo.plan.domain;
+
+import com.jabiseo.certificate.domain.Certificate;
+import com.jabiseo.member.domain.Member;
+import fixture.CertificateFixture;
+import fixture.MemberFixture;
+import fixture.PlanItemFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("플랜 Entity 테스트")
+class PlanTest {
+
+    Plan plan;
+    Certificate certificate; // setUp시 고정
+    Member member; // setUp시 고정
+
+    @BeforeEach
+    void setUp() throws Exception {
+        certificate = CertificateFixture.createCertificate();
+        member = MemberFixture.createMember();
+
+        List<PlanItem> originalItems = List.of(
+                mockDailyItem(ActivityType.STUDY),
+                mockDailyItem(ActivityType.EXAM),
+                mockDailyItem(ActivityType.PROBLEM),
+                mockWeeklyItem(ActivityType.STUDY),
+                mockWeeklyItem(ActivityType.EXAM)
+        );
+        plan = new Plan(certificate, member, null, new ArrayList<>(originalItems));
+    }
+
+    @Test
+    @DisplayName("기존 플랜 아이템 목록과 새 목록 중 기존에 없는 목록을 가져온다.")
+    void getNewItemsSuccess() {
+        //given
+        // Time 이 리턴되어야 한다. (1개)
+        List<PlanItem> newDailyItemsRequest = List.of(
+                mockDailyItem(ActivityType.STUDY), // exist item
+                mockDailyItem(ActivityType.EXAM), // exist item
+                mockDailyItem(ActivityType.TIME) // new item
+        );
+
+        // Problem이 리턴되어야 한다 (1개)
+        List<PlanItem> newWeeklyItemsRequest = List.of(
+                mockWeeklyItem(ActivityType.EXAM), // exist item
+                mockWeeklyItem(ActivityType.STUDY), // exist item
+                mockWeeklyItem(ActivityType.PROBLEM) // new item
+        );
+        //when
+        List<PlanItem> newItems = plan.getNewItems(newDailyItemsRequest, newWeeklyItemsRequest);
+
+        //then
+        assertThat(newItems.size()).isEqualTo(2);
+        assertThat(newItems.stream()
+                .anyMatch((item) -> item.getActivityType().equals(ActivityType.TIME)
+                        && item.getGoalType().equals(GoalType.DAILY)))
+                .isTrue();
+        assertThat(newItems.stream()
+                .anyMatch((item) -> item.getActivityType().equals(ActivityType.PROBLEM)
+                        && item.getGoalType().equals(GoalType.WEEKLY)))
+                .isTrue();
+    }
+
+    @Test
+    @DisplayName("기존 플랜 아이템 목록과 새 목록 중 기존에 있는 아이템 목록을 가져온다.")
+    void planExistingItems() {
+        //given
+        List<PlanItem> newDailyItemsRequest = List.of(
+                mockDailyItem(ActivityType.STUDY), // exist item
+                mockDailyItem(ActivityType.EXAM), // exist item
+                mockDailyItem(ActivityType.TIME) // new item
+        );
+        List<PlanItem> newWeeklyItemsRequest = List.of(
+                mockWeeklyItem(ActivityType.EXAM), // exist item
+                mockWeeklyItem(ActivityType.STUDY), // exist item
+                mockWeeklyItem(ActivityType.PROBLEM) // new item
+        );
+        //when
+        List<PlanItem> newItems = plan.getExistItems(newDailyItemsRequest, newWeeklyItemsRequest);
+
+        //then
+        assertThat(newItems.size()).isEqualTo(4);
+        assertThat(newItems.stream()
+                .anyMatch((item) -> item.getActivityType().equals(ActivityType.STUDY)
+                        && item.getGoalType().equals(GoalType.DAILY)))
+                .isTrue();
+        assertThat(newItems.stream()
+                .anyMatch((item) -> item.getActivityType().equals(ActivityType.EXAM)
+                        && item.getGoalType().equals(GoalType.DAILY)))
+                .isTrue();
+        assertThat(newItems.stream()
+                .anyMatch((item) -> item.getActivityType().equals(ActivityType.STUDY)
+                        && item.getGoalType().equals(GoalType.WEEKLY)))
+                .isTrue();
+        assertThat(newItems.stream()
+                .anyMatch((item) -> item.getActivityType().equals(ActivityType.EXAM)
+                        && item.getGoalType().equals(GoalType.WEEKLY)))
+                .isTrue();
+    }
+
+    @Test
+    @DisplayName("기존 플랜 아이템 목록을 가져올 시, PlanItem 의 target 값은 새로운 값으로 리턴된다.")
+    void planExistingItemsTargetValueIsCorrect() {
+        //given
+        List<PlanItem> newDailyItemsRequest = List.of(
+                new PlanItem(null, ActivityType.EXAM, GoalType.DAILY, 10)
+        );
+        List<PlanItem> newWeeklyItemsRequest = List.of();
+
+        List<PlanItem> originalItems = List.of(new PlanItem(null, ActivityType.EXAM, GoalType.DAILY, 5));
+
+        plan = new Plan(certificate, member, null, originalItems);
+
+        //when
+        List<PlanItem> newItems = plan.getExistItems(newDailyItemsRequest, newWeeklyItemsRequest);
+
+        //then
+        assertThat(newItems.size()).isEqualTo(1);
+        assertThat(newItems.stream()
+                .anyMatch((item) -> item.getActivityType().equals(ActivityType.EXAM)
+                        && item.getGoalType().equals(GoalType.DAILY)))
+                .isTrue();
+        assertThat(newItems.get(0).getTargetValue()).isEqualTo(newDailyItemsRequest.get(0).getTargetValue());
+    }
+
+    @Test
+    @DisplayName("기존 플랜 아이템 목록과 새 목록 중 삭제될 아이템 목록을 가져온다.")
+    void planDeleteItems() {
+        //given, 아래 6개의 아이템이 아닌 기존 목록의 item들 중 없는 값을 가져와야 한다.
+        List<PlanItem> newDailyItemsRequest = List.of(
+                mockDailyItem(ActivityType.STUDY), // exist item
+                mockDailyItem(ActivityType.EXAM), // exist item
+                mockDailyItem(ActivityType.TIME) // new item
+        );
+        List<PlanItem> newWeeklyItemsRequest = List.of(
+                mockWeeklyItem(ActivityType.EXAM), // exist item
+                mockWeeklyItem(ActivityType.STUDY), // exist item
+                mockWeeklyItem(ActivityType.PROBLEM) // new item
+        );
+        // Problem이 삭제될 예정. (setUp)
+
+        //when
+        List<PlanItem> result = plan.getDeletedItems(newDailyItemsRequest, newWeeklyItemsRequest);
+
+        //then
+        assertThat(result.size()).isEqualTo(1);
+        assertThat(result.stream()
+                .anyMatch((item) -> item.getActivityType().equals(ActivityType.PROBLEM)
+                        && item.getGoalType().equals(GoalType.DAILY)))
+                .isTrue();
+    }
+
+    @Test
+    @DisplayName("플랜 수정시, 기존 플랜의 값이 추가되거나 삭제된다.")
+    void modifyPlanTest(){
+        //given
+        List<PlanItem> newDailyItemsRequest = List.of(
+                mockDailyItem(ActivityType.STUDY), // exist item
+                mockDailyItem(ActivityType.EXAM), // exist item
+                mockDailyItem(ActivityType.TIME) // new item
+        );
+        List<PlanItem> newWeeklyItemsRequest = List.of(
+                mockWeeklyItem(ActivityType.EXAM), // exist item
+                mockWeeklyItem(ActivityType.STUDY), // exist item
+                mockWeeklyItem(ActivityType.PROBLEM) // new item
+        );
+        // Problem이 삭제될 예정. (setUp)
+        int expectedSize = this.plan.getPlanItems().size() - 1 + 2;// -1(Problem), 2 => 위의 2개의 new items
+
+        //when
+        plan.modifyPlanItems(newDailyItemsRequest, newWeeklyItemsRequest);
+        List<PlanItem> planItems = plan.getPlanItems();
+
+        //then
+        assertThat(planItems.size()).isEqualTo(expectedSize);
+    }
+
+    private PlanItem mockDailyItem(ActivityType type) {
+        return PlanItemFixture.createPlanItem(type, GoalType.DAILY);
+    }
+
+    private PlanItem mockWeeklyItem(ActivityType type) {
+        return PlanItemFixture.createPlanItem(type, GoalType.WEEKLY);
+    }
+}
+

--- a/jabiseo-domain/src/test/java/com/jabiseo/plan/domain/PlanTest.java
+++ b/jabiseo-domain/src/test/java/com/jabiseo/plan/domain/PlanTest.java
@@ -159,7 +159,7 @@ class PlanTest {
 
     @Test
     @DisplayName("플랜 수정시, 기존 플랜의 값이 추가되거나 삭제된다.")
-    void modifyPlanTest(){
+    void modifyPlanTest() {
         //given
         List<PlanItem> newDailyItemsRequest = List.of(
                 mockDailyItem(ActivityType.STUDY), // exist item
@@ -173,9 +173,12 @@ class PlanTest {
         );
         // Problem이 삭제될 예정. (setUp)
         int expectedSize = this.plan.getPlanItems().size() - 1 + 2;// -1(Problem), 2 => 위의 2개의 new items
+        List<PlanItem> existItems = plan.getExistItems(newDailyItemsRequest, newWeeklyItemsRequest);
+        List<PlanItem> newItems = plan.getNewItems(newDailyItemsRequest, newWeeklyItemsRequest);
+        List<PlanItem> deletedItems = plan.getDeletedItems(newDailyItemsRequest, newWeeklyItemsRequest);
 
         //when
-        plan.modifyPlanItems(newDailyItemsRequest, newWeeklyItemsRequest);
+        plan.modifyPlanItems(existItems, newItems, deletedItems);
         List<PlanItem> planItems = plan.getPlanItems();
 
         //then


### PR DESCRIPTION
## PR 변경된 내용
- 플랜 수정 API 구현
- 플랜 삭제 API 구현

### 플랜 수정 
- 플랜 수정시 입력값은 플랜 생성과 동일, 같은 입력값에서 **이미 있는 플랜 아이템**(1) / **새로운 플랜 아이템**(2) / **없어지는 플랜 아이템** (3)에 따라 각각의 로직에따라 현재 날짜의 Progress를 업데이트 처리.
- PlanProgressService에 수정과 삭제 관련된 메소드 추가 후 Progress 수정 및 삭제 로직 진행
- Plan Entity에 위 1, 2, 3 의 타겟 아이템을 선택하는 로직 추가, 테스트코드 작성
- 케스케이드 적용 및 orphanRemoval 으로 Plan에서 Item을 수정함에따라 DB에 반영되게 구성

### 플랜 삭제
- 플랜 삭제시 Plan과 Item 삭제
- PlanProgress는 JPQL을 통해 SQL을 통한 쿼리 한방으로 삭제.

## 추가 내용
- 기존 PlanProgressRepository에서 findAllByProgressDateBetweenAndGoalType 메소드가 Plan 파라미터가 없어서 전체 Progress를 가져오는 상황, Plan 파라미터 추가 
- 플랜 생성시 검사 로직 변경
- 기존 : endAt 기준 미래 플랜이 있는지 검사 -> endAt기준 삭제, member , certificate만으로 검사 진행 
- 쿼리 최적화 : 노션 참고, 개발 DB 인덱스 적용 예정

## 참조
Closes #70 
