### PR TITLE
Feat(Analysis): 취약점 분석 알고리즘 개선

### DIFF
--- a/jabiseo-domain/src/main/java/com/jabiseo/analysis/domain/ProblemSolvingAnalysisType.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/analysis/domain/ProblemSolvingAnalysisType.java
@@ -1,0 +1,43 @@
+package com.jabiseo.analysis.domain;
+
+import com.jabiseo.analysis.exception.AnalysisBusinessException;
+import com.jabiseo.analysis.exception.AnalysisErrorCode;
+import lombok.Getter;
+
+import java.util.Arrays;
+import java.util.Comparator;
+
+@Getter
+public enum ProblemSolvingAnalysisType {
+
+    SHORT_TERM(1, 0.5, 14, 200),
+    MID_TERM(2, 0.3, 30, 300),
+    LONG_TERM(3, 0.2, 90, 500);
+
+    final int priority;
+    final double weight;
+    final int maxPeriod;
+    final int maxCount;
+
+    ProblemSolvingAnalysisType(int priority, double weight, int maxPeriod, int maxCount) {
+        this.priority = priority;
+        this.weight = weight;
+        this.maxPeriod = maxPeriod;
+        this.maxCount = maxCount;
+    }
+
+    public static ProblemSolvingAnalysisType getLongestAnalysisType() {
+        return Arrays.stream(ProblemSolvingAnalysisType.values())
+                .max(Comparator.comparingInt(ProblemSolvingAnalysisType::getPriority))
+                .orElseThrow(() -> new IllegalStateException("No ProblemSolvingAnalysisType found"));
+    }
+
+    public static ProblemSolvingAnalysisType fromPeriodAndCount(int period, int count) {
+        return Arrays.stream(ProblemSolvingAnalysisType.values())
+                .sorted(Comparator.comparingInt(ProblemSolvingAnalysisType::getPriority))
+                .filter(type -> period <= type.getMaxPeriod() && count <= type.getMaxCount())
+                .findFirst()
+                .orElseThrow(() -> new AnalysisBusinessException(AnalysisErrorCode.CANNOT_ANALYSE_PROBLEM_SOLVING));
+    }
+
+}

--- a/jabiseo-domain/src/main/java/com/jabiseo/analysis/domain/ProblemSolvingAnalysisType.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/analysis/domain/ProblemSolvingAnalysisType.java
@@ -10,32 +10,33 @@ import java.util.Comparator;
 @Getter
 public enum ProblemSolvingAnalysisType {
 
-    SHORT_TERM(1, 0.5, 14, 200),
-    MID_TERM(2, 0.3, 30, 300),
-    LONG_TERM(3, 0.2, 90, 500);
+    // maxPeriodDay가 커지면 maxCount도 증가해야 함
+    // 단기 분석 타입: 최근 14일 이내에 최대 200개의 문제 풀이에 가중치 0.5 적용
+    SHORT_TERM( 0.5, 14, 200),
+    // 중기 분석 타입: 최근 30일 이내에 최대 300개의 문제 풀이에 가중치 0.3 적용
+    MID_TERM( 0.3, 30, 300),
+    // 단기 분석 타입: 최근 90일 이내에 최대 500개의 문제 풀이에 가중치 0.2 적용
+    LONG_TERM( 0.2, 90, 500);
 
-    final int priority;
     final double weight;
-    final int maxPeriod;
+    final int maxPeriodDay;
     final int maxCount;
 
-    ProblemSolvingAnalysisType(int priority, double weight, int maxPeriod, int maxCount) {
-        this.priority = priority;
+    ProblemSolvingAnalysisType(double weight, int maxPeriodDay, int maxCount) {
         this.weight = weight;
-        this.maxPeriod = maxPeriod;
+        this.maxPeriodDay = maxPeriodDay;
         this.maxCount = maxCount;
     }
 
-    public static ProblemSolvingAnalysisType getLongestAnalysisType() {
-        return Arrays.stream(ProblemSolvingAnalysisType.values())
-                .max(Comparator.comparingInt(ProblemSolvingAnalysisType::getPriority))
-                .orElseThrow(() -> new IllegalStateException("No ProblemSolvingAnalysisType found"));
+    public static ProblemSolvingAnalysisType getLongestPeriodAnalysisType() {
+        return LONG_TERM;
     }
 
-    public static ProblemSolvingAnalysisType fromPeriodAndCount(int period, int count) {
+    // 푼 기간과 최근 푼 순서가 주어지면 그에 맞는 ProblemSolvingAnalysisType을 반환한다.
+    public static ProblemSolvingAnalysisType fromPeriodAndCount(int period, int sequence) {
         return Arrays.stream(ProblemSolvingAnalysisType.values())
-                .sorted(Comparator.comparingInt(ProblemSolvingAnalysisType::getPriority))
-                .filter(type -> period <= type.getMaxPeriod() && count <= type.getMaxCount())
+                .sorted(Comparator.comparingInt(ProblemSolvingAnalysisType::getMaxPeriodDay))
+                .filter(type -> period <= type.getMaxPeriodDay() && sequence <= type.getMaxCount())
                 .findFirst()
                 .orElseThrow(() -> new AnalysisBusinessException(AnalysisErrorCode.CANNOT_ANALYSE_PROBLEM_SOLVING));
     }

--- a/jabiseo-domain/src/main/java/com/jabiseo/analysis/exception/AnalysisErrorCode.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/analysis/exception/AnalysisErrorCode.java
@@ -9,6 +9,7 @@ public enum AnalysisErrorCode implements ErrorCode {
     CANNOT_CALCULATE_VULNERABILITY("취약점 분석을 할 수 없습니다.", "ANA_001", ErrorCode.INTERNAL_SERVER_ERROR),
     CANNOT_FIND_VECTOR("벡터를 찾을 수 없습니다.", "ANA_002", ErrorCode.INTERNAL_SERVER_ERROR),
     NOT_ENOUGH_SOLVED_PROBLEMS("문제를 충분히 풀지 않아서 분석할 수 없습니다.", "ANA_003", ErrorCode.BAD_REQUEST),
+    CANNOT_ANALYSE_PROBLEM_SOLVING("분석할 수 없는 문제 풀이 기록입니다.", "ANA_004", ErrorCode.INTERNAL_SERVER_ERROR),
     ;
 
     private final String message;

--- a/jabiseo-domain/src/main/java/com/jabiseo/analysis/service/AnalysisService.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/analysis/service/AnalysisService.java
@@ -57,9 +57,9 @@ public class AnalysisService {
 
     List<Float> findVulnerableVector(Member member, Certificate certificate) {
 
-        ProblemSolvingAnalysisType longestAnalysisType = ProblemSolvingAnalysisType.getLongestAnalysisType();
-        LocalDateTime fromDate = now().minusDays(longestAnalysisType.getMaxPeriod());
-        Pageable pageable = Pageable.ofSize(longestAnalysisType.getMaxCount());
+        ProblemSolvingAnalysisType longestPeriodAnalysisType = ProblemSolvingAnalysisType.getLongestPeriodAnalysisType();
+        LocalDateTime fromDate = now().minusDays(longestPeriodAnalysisType.getMaxPeriodDay());
+        Pageable pageable = Pageable.ofSize(longestPeriodAnalysisType.getMaxCount());
 
         List<ProblemSolving> longestTermProblemSolvings = problemSolvingRepository.findWithLearningByCreatedAtAfterOrderByCreatedAtDesc(member, certificate, fromDate, pageable);
 

--- a/jabiseo-domain/src/main/java/com/jabiseo/analysis/service/AnalysisService.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/analysis/service/AnalysisService.java
@@ -89,6 +89,7 @@ public class AnalysisService {
 
     List<Float> calculateVulnerableVector(List<Long> distinctProblemIds, Map<Long, List<Float>> problemIdToVector, Map<Long, Double> problemIdToWeight) {
         return distinctProblemIds.stream()
+                // 문제 ID별로 벡터의 각 요소에 가중치를 곱한다.
                 .map(problemId -> {
                     List<Float> vector = problemIdToVector.get(problemId);
                     double weight = problemIdToWeight.get(problemId);
@@ -96,6 +97,7 @@ public class AnalysisService {
                             .map(value -> (float) (value * weight))
                             .toList();
                 })
+                // 문제 ID별로 계산된 벡터를 최종 합연산한다.
                 .reduce((vector1, vector2) -> IntStream.range(0, vector1.size())
                         .mapToObj(i -> vector1.get(i) + vector2.get(i))
                         .collect(Collectors.toList()))
@@ -106,6 +108,7 @@ public class AnalysisService {
     double calculateWeight(ProblemSolving problemSolving, int sequence) {
         int daysAgo = (int) ChronoUnit.DAYS.between(problemSolving.getLearning().getCreatedAt(), now());
         ProblemSolvingAnalysisType analysisType = ProblemSolvingAnalysisType.fromPeriodAndCount(daysAgo, sequence);
+        // 문제를 맞혔을 경우 -1을 곱해 가중치를 계산한다.
         return problemSolving.isCorrect() ? -analysisType.getWeight() : analysisType.getWeight();
     }
 

--- a/jabiseo-domain/src/main/java/com/jabiseo/learning/domain/ProblemSolvingRepository.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/learning/domain/ProblemSolvingRepository.java
@@ -2,15 +2,26 @@ package com.jabiseo.learning.domain;
 
 import com.jabiseo.certificate.domain.Certificate;
 import com.jabiseo.member.domain.Member;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 public interface ProblemSolvingRepository extends JpaRepository<ProblemSolving, Long> {
 
-    @Query("select ps from ProblemSolving ps join fetch ps.learning l where ps.member = :member and l.certificate = :learning_certificate and l.createdAt > :createdAt")
-    List<ProblemSolving> findByMemberAndCertificateAndCreatedAtAfterWithLearning(Member member, Certificate learning_certificate, LocalDateTime createdAt);
+    @Query("SELECT ps " +
+           "FROM ProblemSolving ps " +
+           "JOIN FETCH ps.learning l " +
+           "WHERE ps.member = :member AND l.certificate = :certificate AND l.createdAt > :fromDate " +
+           "ORDER BY l.createdAt DESC")
+    List<ProblemSolving> findWithLearningByCreatedAtAfterOrderByCreatedAtDesc(
+            @Param("member") Member member,
+            @Param("certificate") Certificate certificate,
+            @Param("fromDate") LocalDateTime fromDate,
+            Pageable pageable
+    );
 
 }

--- a/jabiseo-domain/src/main/java/com/jabiseo/problem/domain/querydsl/ProblemRepositoryCustomImpl.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/problem/domain/querydsl/ProblemRepositoryCustomImpl.java
@@ -128,7 +128,7 @@ public class ProblemRepositoryCustomImpl implements ProblemRepositoryCustom {
                 .join(problem.exam, exam)
                 .join(problem.subject, subject)
                 .join(bookmark).on(bookmark.problem.id.eq(problem.id))
-                .where(examIdEq(examId), subjectIdsIn(subjectIds));
+                .where(memberIdEq(memberId), examIdEq(examId), subjectIdsIn(subjectIds));
 
         return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
     }

--- a/jabiseo-domain/src/test/java/com/jabiseo/analysis/domain/ProblemSolvingAnalysisTypeTest.java
+++ b/jabiseo-domain/src/test/java/com/jabiseo/analysis/domain/ProblemSolvingAnalysisTypeTest.java
@@ -36,8 +36,8 @@ class ProblemSolvingAnalysisTypeTest {
     @ParameterizedTest
     @CsvSource({
             "91, 100",
-            "89, 600",
-            "91, 600"
+            "89, 501",
+            "91, 501"
     })
     void fromPeriodAndCountWithDefault(int period, int count) {
         // when & then

--- a/jabiseo-domain/src/test/java/com/jabiseo/analysis/domain/ProblemSolvingAnalysisTypeTest.java
+++ b/jabiseo-domain/src/test/java/com/jabiseo/analysis/domain/ProblemSolvingAnalysisTypeTest.java
@@ -1,0 +1,62 @@
+package com.jabiseo.analysis.domain;
+
+import com.jabiseo.analysis.exception.AnalysisBusinessException;
+import com.jabiseo.analysis.exception.AnalysisErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@DisplayName("ProblemSolvingAnalysisType 테스트")
+@ExtendWith(MockitoExtension.class)
+class ProblemSolvingAnalysisTypeTest {
+
+    @DisplayName("가장 긴 분석 타입을 반환한다.")
+    @Test
+    void getLongestAnalysisType() {
+        // given
+        ProblemSolvingAnalysisType expected = ProblemSolvingAnalysisType.LONG_TERM;
+
+        // when
+        ProblemSolvingAnalysisType actual = ProblemSolvingAnalysisType.getLongestAnalysisType();
+
+        // then
+        assertEquals(expected, actual);
+    }
+
+    @DisplayName("기간과 문제 수에 따른 분석 타입을 반환한다.")
+    @ParameterizedTest
+    @CsvSource({
+            "0, 0, SHORT_TERM",
+            "13, 199, SHORT_TERM",
+            "14, 200, SHORT_TERM",
+            "30, 300, MID_TERM",
+            "90, 500, LONG_TERM"
+    })
+    void fromPeriodAndCount(int period, int count, ProblemSolvingAnalysisType expected) {
+        // when
+        ProblemSolvingAnalysisType actual = ProblemSolvingAnalysisType.fromPeriodAndCount(period, count);
+
+        // then
+        assertEquals(expected, actual);
+    }
+
+    @DisplayName("기간과 문제 수가 올바르지 않을 경우 예외처리한다.")
+    @ParameterizedTest
+    @CsvSource({
+            "91, 100",
+            "89, 600",
+            "91, 600"
+    })
+    void fromPeriodAndCountWithDefault(int period, int count) {
+        // when & then
+        assertThatThrownBy(() -> ProblemSolvingAnalysisType.fromPeriodAndCount(period, count))
+                .isInstanceOf(AnalysisBusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", AnalysisErrorCode.CANNOT_ANALYSE_PROBLEM_SOLVING);
+    }
+}

--- a/jabiseo-domain/src/test/java/com/jabiseo/analysis/domain/ProblemSolvingAnalysisTypeTest.java
+++ b/jabiseo-domain/src/test/java/com/jabiseo/analysis/domain/ProblemSolvingAnalysisTypeTest.java
@@ -3,7 +3,6 @@ package com.jabiseo.analysis.domain;
 import com.jabiseo.analysis.exception.AnalysisBusinessException;
 import com.jabiseo.analysis.exception.AnalysisErrorCode;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -15,19 +14,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @DisplayName("ProblemSolvingAnalysisType 테스트")
 @ExtendWith(MockitoExtension.class)
 class ProblemSolvingAnalysisTypeTest {
-
-    @DisplayName("가장 긴 분석 타입을 반환한다.")
-    @Test
-    void getLongestAnalysisType() {
-        // given
-        ProblemSolvingAnalysisType expected = ProblemSolvingAnalysisType.LONG_TERM;
-
-        // when
-        ProblemSolvingAnalysisType actual = ProblemSolvingAnalysisType.getLongestAnalysisType();
-
-        // then
-        assertEquals(expected, actual);
-    }
 
     @DisplayName("기간과 문제 수에 따른 분석 타입을 반환한다.")
     @ParameterizedTest

--- a/jabiseo-domain/src/test/java/com/jabiseo/analysis/service/AnalysisServiceTest.java
+++ b/jabiseo-domain/src/test/java/com/jabiseo/analysis/service/AnalysisServiceTest.java
@@ -1,31 +1,39 @@
 package com.jabiseo.analysis.service;
 
+import com.jabiseo.analysis.exception.AnalysisBusinessException;
+import com.jabiseo.analysis.exception.AnalysisErrorCode;
 import com.jabiseo.certificate.domain.Certificate;
-import com.jabiseo.learning.domain.Learning;
 import com.jabiseo.learning.domain.ProblemSolving;
+import com.jabiseo.learning.domain.ProblemSolvingRepository;
 import com.jabiseo.member.domain.Member;
-import com.jabiseo.problem.domain.Problem;
-import fixture.ProblemFixture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
 
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.IntStream;
 
 import static fixture.CertificateFixture.createCertificate;
 import static fixture.LearningFixture.createLearning;
 import static fixture.MemberFixture.createMember;
 import static fixture.ProblemFixture.createProblem;
 import static fixture.ProblemSolvingFixture.createProblemSolving;
+import static java.time.LocalDateTime.now;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
 @DisplayName("분석 서비스 테스트")
 @ExtendWith(MockitoExtension.class)
@@ -33,6 +41,12 @@ class AnalysisServiceTest {
 
     @InjectMocks
     AnalysisService sut;
+
+    @Mock
+    ProblemSolvingRepository problemSolvingRepository;
+
+    @Mock
+    VulnerabilityProvider vulnerabilityProvider;
 
     private Member member;
 
@@ -46,63 +60,115 @@ class AnalysisServiceTest {
         this.certificate = createCertificate(certificateId);
     }
 
-    @ParameterizedTest
-    @CsvSource(value = {"0:true:-1.0", "0:false:1.0", "1:true:-0.5", "364:false:0.002739726", "126:true:-0.007874016"}, delimiter = ':')
-    @DisplayName("[calculateVulnerableVector 가중치 테스트] N일 차이가 날 경우 1/(N+1)의 가중치를 부여한다. 맞은 경우 가중치는 음수이다.")
-    void givenDifferentCreatedAt_whenFindVulnerableVector_thenApplyWeight(int dateDifference, boolean isCorrect, double result) {
+    @Test
+    @DisplayName("[findVulnerableVector 테스트] 문제 풀이 분석의 가장 긴 기간인 90일 이내의 문제 풀이를 500건까지 조회한다.")
+    void givenProblemSolvings_whenFindVulnerableVector_thenFindProblemSolvings() {
         //given
         Long problemId = 3L;
-        Problem problem = createProblem(problemId);
-        Long learningId = 4L;
-        Learning learning = createLearning(learningId, certificate, LocalDateTime.now().minusDays(dateDifference));
         List<ProblemSolving> problemSolvings = List.of(
-                createProblemSolving(5L, member, problem, learning, isCorrect)
+                createProblemSolving(1L, member, createProblem(problemId), createLearning(4L, certificate, now()), true)
         );
-        List<Float> problemVector = List.of(1.0f, 2.0f, 3.0f);
-        Map<Long, List<Float>> problemIdToVector = Map.of(problemId, problemVector);
+
+        // 90일 전의 날짜 계산
+        LocalDateTime ninetyDaysAgo = now().minusDays(90);
+        PageRequest pageRequest = PageRequest.of(0, 500);
+
+        given(problemSolvingRepository.findWithLearningByCreatedAtAfterOrderByCreatedAtDesc(
+                eq(member), eq(certificate), any(LocalDateTime.class), any(PageRequest.class)))
+                .willReturn(problemSolvings);
+        given(vulnerabilityProvider.findVectorsOfProblems(any(), any()))
+                .willReturn(Map.of(problemId, List.of(1.0f, 2.0f, 3.0f)));
 
         //when
-        List<Float> vulnerableVector = sut.calculateVulnerableVector(problemSolvings, problemIdToVector);
+        sut.findVulnerableVector(member, certificate);
 
         //then
-        IntStream.range(0, problemVector.size())
-                .forEach(i -> {
-                    float expected = (float) (problemVector.get(i) * result);
-                    float actual = vulnerableVector.get(i);
-                    assertThat(actual).isEqualTo(expected);
-                });
+        ArgumentCaptor<LocalDateTime> dateCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
+        ArgumentCaptor<PageRequest> pageRequestCaptor = ArgumentCaptor.forClass(PageRequest.class);
+        verify(problemSolvingRepository).findWithLearningByCreatedAtAfterOrderByCreatedAtDesc(
+                eq(member), eq(certificate), dateCaptor.capture(), pageRequestCaptor.capture());
+        // 검증: 90일 전의 날짜인지 확인
+        assertThat(dateCaptor.getValue()).isAfterOrEqualTo(ninetyDaysAgo);
+        // 검증: PageRequest가 500건인지 확인
+        assertThat(pageRequestCaptor.getValue()).isEqualTo(pageRequest);
+    }
+
+
+    @Test
+    @DisplayName("[findVulnerableVector 테스트] 90일 이내에 문제를 푼 기록이 없으면 예외처리한다.")
+    void givenNoProblemSolving_whenFindVulnerableVector_thenThrowException() {
+        //given
+        given(problemSolvingRepository.findWithLearningByCreatedAtAfterOrderByCreatedAtDesc(eq(member), eq(certificate), any(LocalDateTime.class), any(PageRequest.class)))
+                .willReturn(List.of());
+
+        //when, then
+        assertThatThrownBy(() -> sut.findVulnerableVector(member, certificate))
+                .isInstanceOf(AnalysisBusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", AnalysisErrorCode.NOT_ENOUGH_SOLVED_PROBLEMS);
+    }
+
+    @ParameterizedTest
+    @DisplayName("[calculateWeight 테스트] 문제 풀이의 가중치를 계산한다. 맞은 문제는 타입 가중치에 -1을 곱한다.")
+    @CsvSource(value = {
+            "1, 2, true, -0.5",
+            "2, 219, false, 0.3",
+            "19, 70, true, -0.3"
+    })
+    void givenProblemSolving_whenCalculateWeight_thenCalculateWeight(int daysAgo, int period, boolean isCorrect, double expected) {
+        //given
+        ProblemSolving problemSolving = createProblemSolving(1L, member, createProblem(1L), createLearning(4L, certificate, now().minusDays(daysAgo)), isCorrect);
+
+        //when
+        double weight = sut.calculateWeight(problemSolving, period);
+
+        //then
+        assertThat(weight).isEqualTo(expected);
     }
 
     @Test
-    @DisplayName("[calculateVulnerableVector 테스트] 풀었던 문제들의 가중치를 곱하여 더한 후 반환한다.")
-    void givenProblemSolvings_whenCalculateVulnerableVector_thenSumWeightedVectors() {
+    @DisplayName("[calculateWeightsOfProblems 테스트] 문제 풀이들의 문제 ID별 가중치를 계산해 Map으로 반환한다.")
+    void givenProblemSolvings_whenCalculateWeightsOfProblems_thenCalculateWeights() {
         //given
-        List<Long> problemIds = List.of(1L, 2L, 3L);
-        List<Problem> problems = problemIds.stream()
-                .map(ProblemFixture::createProblem)
-                .toList();
-        List<Long> learningIds = List.of(4L, 5L, 6L);
-        List<Learning> learnings = List.of(
-                createLearning(learningIds.get(0), certificate, LocalDateTime.now().minusDays(0)),
-                createLearning(learningIds.get(1), certificate, LocalDateTime.now().minusDays(1)),
-                createLearning(learningIds.get(2), certificate, LocalDateTime.now().minusDays(2))
-        );
+        List<Long> problemIds = List.of(1L, 2L);
+        List<Integer> daysAgo = List.of(2, 19, 70);
         List<ProblemSolving> problemSolvings = List.of(
-                createProblemSolving(7L, member, problems.get(0), learnings.get(0), true),
-                createProblemSolving(8L, member, problems.get(1), learnings.get(1), false),
-                createProblemSolving(9L, member, problems.get(2), learnings.get(2), true)
-        );
-        Map<Long, List<Float>> problemIdToVector = Map.of(
-                problemIds.get(0), List.of(1.0f, 2.0f, 3.0f),
-                problemIds.get(1), List.of(4.0f, 5.0f, 6.0f),
-                problemIds.get(2), List.of(7.0f, 8.0f, 9.0f)
+                createProblemSolving(1L, member, createProblem(problemIds.get(0)), createLearning(4L, certificate, now().minusDays(daysAgo.get(0))), true),
+                createProblemSolving(2L, member, createProblem(problemIds.get(0)), createLearning(5L, certificate, now().minusDays(daysAgo.get(1))), false),
+                createProblemSolving(3L, member, createProblem(problemIds.get(1)), createLearning(6L, certificate, now().minusDays(daysAgo.get(2))), true)
         );
 
         //when
-        List<Float> vulnerableVector = sut.calculateVulnerableVector(problemSolvings, problemIdToVector);
+        Map<Long, Double> problemIdToWeight = sut.calculateWeightsOfProblems(problemSolvings);
 
         //then
-        List<Float> expected = List.of(-1.0f + 1.0f - 1.3333333f, -2.0f + 2.5f - 2.6666667f, -3.0f + 3.0f - 3.0f);
-        assertThat(vulnerableVector).isEqualTo(expected);
+        assertThat(problemIdToWeight).contains(
+                Map.entry(problemIds.get(0), -0.5 + 0.3),
+                Map.entry(problemIds.get(1), -0.2)
+        );
+    }
+
+    @Test
+    @DisplayName("[calculateVulnerableVector 테스트] 문제 ID별로 가중치를 곱하여 더한 후 반환한다.")
+    void givenProblemSolvings_whenCalculateVulnerableVector_thenSumWeightedVectors() {
+        //given
+        List<Long> distinctProblemIds = List.of(1L, 2L, 3L);
+        Map<Long, List<Float>> problemIdToVector = Map.of(
+                distinctProblemIds.get(0), List.of(1.0f, 2.0f, 3.0f),
+                distinctProblemIds.get(1), List.of(4.0f, 5.0f, 6.0f),
+                distinctProblemIds.get(2), List.of(7.0f, 8.0f, 9.0f)
+        );
+        Map<Long, Double> problemIdToWeight = Map.of(
+                distinctProblemIds.get(0), 1.1,
+                distinctProblemIds.get(1), 2.2,
+                distinctProblemIds.get(2), 3.3
+        );
+
+        //when
+        List<Float> vulnerableVector = sut.calculateVulnerableVector(distinctProblemIds, problemIdToVector, problemIdToWeight);
+
+        //then
+        assertThat(vulnerableVector.get(0)).isEqualTo(1.1f + 8.8f + 23.1f);
+        assertThat(vulnerableVector.get(1)).isEqualTo(2.2f + 11.0f + 26.4f);
+        assertThat(vulnerableVector.get(2)).isEqualTo(3.3f + 13.2f + 29.7f);
     }
 }


### PR DESCRIPTION
## PR 변경된 내용
- 기존에 N일 경과 시 1/(N+1)의 가중치를 부과
- 경과일과 최근에 푼 순서에 따라 단기/중기/장기로 나눠 가중치 부과하는 것으로 변경
### 로직 개선
- 문제를 푼 수에 관계없이 벡터의 합을 구하는 연산을 푼 문제만큼 수행
  - 예를 들어, 기존에는 1번 문제를 100번 풀고 2번 문제를 100번 풀었다면, 각 경우의 가중치를 계산해서 200개의 벡터를 합연산
  - 이를 개선해 문제별 가중치를 계산해서 합하는 것으로 변경. 위의 경우 2개의 벡터만 더하는 것으로 로직 개선

## 추가 내용
- 북마크에서 카운트 쿼리와 내용 쿼리가 다를 수 있던 부분 수정

## 참조
Closes #74 
