### PR TITLE
Feat(*): 모니터링을 위해 개발 환경에서 파일로 로깅

### DIFF
--- a/.github/workflows/devcd.yml
+++ b/.github/workflows/devcd.yml
@@ -139,7 +139,7 @@ jobs:
         id: execute
         run: |
           docker stop ${{env.NAME}} && docker rm ${{env.NAME}}
-            docker run -d -p 8080:8080 -e PROFILE=dev --name ${{env.NAME}} --network jabiseo-dev "${{env.ECR_URI}}:${{env.DOCKER_TAG}}"
+            docker run -d -p 8080:8080 -e PROFILE=dev --name ${{env.NAME}} --network jabiseo-dev -v logsVolume:/logs "${{env.ECR_URI}}:${{env.DOCKER_TAG}}"
   result-send-sucess:
     needs:
       - gradle-docker-build

--- a/jabiseo-api/src/main/resources/api.yml
+++ b/jabiseo-api/src/main/resources/api.yml
@@ -48,9 +48,6 @@ management:
       exposure:
         include: "*"
 
-jwt:
-  access-expired-min: 60
-
 ---
 spring:
   config:

--- a/jabiseo-api/src/main/resources/api.yml
+++ b/jabiseo-api/src/main/resources/api.yml
@@ -54,4 +54,6 @@ spring:
     activate:
       on-profile: api-dev
 
-
+log:
+  file:
+    path: ${LOG_PATH}

--- a/jabiseo-api/src/main/resources/logback-dev.xml
+++ b/jabiseo-api/src/main/resources/logback-dev.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <!-- 일반 로그 파일 설정 -->
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>/Users/morenow/Desktop/jabiseo/logs/jabiseo.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>/Users/morenow/Desktop/jabiseo/logs/jabiseo.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- SQL 로그 전용 파일 설정 -->
+    <appender name="SQL_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>/Users/morenow/Desktop/jabiseo/logs/jabiseo_sql.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>/Users/morenow/Desktop/jabiseo/logs/jabiseo_sql.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <charset>UTF-8</charset>
+        </encoder>
+    </appender>
+
+    <!-- 루트 로거: 일반 로그를 파일에만 기록 -->
+    <root level="INFO" additivity="false">
+        <appender-ref ref="FILE"/>
+    </root>
+
+    <!-- Hibernate SQL 로그를 별도 파일에만 기록 -->
+    <logger name="org.hibernate.SQL" level="DEBUG" additivity="false">
+        <appender-ref ref="SQL_FILE"/>
+    </logger>
+
+    <!-- Hibernate의 다른 내부 로거는 비활성화 -->
+    <logger name="org.hibernate" level="OFF"/>
+
+</configuration>

--- a/jabiseo-api/src/main/resources/logback-dev.xml
+++ b/jabiseo-api/src/main/resources/logback-dev.xml
@@ -1,11 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
 
+    <!-- Spring Boot의 log.file.path 설정 읽기 -->
+    <springProperty name="LOG_PATH" source="log.file.path"/>
+
     <!-- 일반 로그 파일 설정 -->
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>/Users/morenow/Desktop/jabiseo/logs/jabiseo.log</file>
+        <file>${LOG_PATH}/jabiseo.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>/Users/morenow/Desktop/jabiseo/logs/jabiseo.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <fileNamePattern>${LOG_PATH}/jabiseo.%d{yyyy-MM-dd}.log</fileNamePattern>
             <maxHistory>30</maxHistory>
         </rollingPolicy>
         <encoder>
@@ -15,9 +18,9 @@
 
     <!-- SQL 로그 전용 파일 설정 -->
     <appender name="SQL_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>/Users/morenow/Desktop/jabiseo/logs/jabiseo_sql.log</file>
+        <file>${LOG_PATH}/jabiseo_sql.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>/Users/morenow/Desktop/jabiseo/logs/jabiseo_sql.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <fileNamePattern>${LOG_PATH}/jabiseo_sql.%d{yyyy-MM-dd}.log</fileNamePattern>
             <maxHistory>30</maxHistory>
         </rollingPolicy>
         <encoder>

--- a/jabiseo-api/src/main/resources/logback-spring.xml
+++ b/jabiseo-api/src/main/resources/logback-spring.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <!-- 로컬 환경에서는 Spring Boot 기본 콘솔 로그 설정 사용 -->
+    <springProfile name="local">
+        <include resource="org/springframework/boot/logging/logback/base.xml"/>
+    </springProfile>
+
+    <!-- dev 환경에서는 logback-dev.xml 설정 사용 -->
+    <springProfile name="dev">
+        <include resource="logback-dev.xml"/>
+    </springProfile>
+
+</configuration>

--- a/jabiseo-domain/src/main/java/com/jabiseo/analysis/domain/ProblemSolvingAnalysisType.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/analysis/domain/ProblemSolvingAnalysisType.java
@@ -15,7 +15,7 @@ public enum ProblemSolvingAnalysisType {
     SHORT_TERM( 0.5, 14, 200),
     // 중기 분석 타입: 최근 30일 이내에 최대 300개의 문제 풀이에 가중치 0.3 적용
     MID_TERM( 0.3, 30, 300),
-    // 단기 분석 타입: 최근 90일 이내에 최대 500개의 문제 풀이에 가중치 0.2 적용
+    // 장기 분석 타입: 최근 90일 이내에 최대 500개의 문제 풀이에 가중치 0.2 적용
     LONG_TERM( 0.2, 90, 500);
 
     final double weight;

--- a/jabiseo-domain/src/main/resources/domain.yml
+++ b/jabiseo-domain/src/main/resources/domain.yml
@@ -20,7 +20,7 @@ spring:
       ddl-auto: update
     properties:
       hibernate:
-        # show_sql: true
+        show_sql: true
         format_sql: true
 
 logging.level:
@@ -35,7 +35,6 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
-      format_sql: true
-    show-sql: true
-
-
+    properties:
+      hibernate:
+        show_sql: false

--- a/script/developcompose/Readme.md
+++ b/script/developcompose/Readme.md
@@ -143,3 +143,8 @@ docker compose down
 ### 모니터링
 - 프로메테우스, 그라파나 설정
 - 현재 Local(인텔리제이) WAS를 host.docker.internal:9292 경로로 직접 가져옴.(수정 예정)
+
+### elk
+- Filebeat, Logstash 설정
+- filebeat.yml: filebeat 설정 파일
+- logstash.conf: logstash 설정 파일, OpenSearch 관련된 변수는 노션 참고

--- a/script/developcompose/database/docker-compose.yml
+++ b/script/developcompose/database/docker-compose.yml
@@ -23,7 +23,9 @@ services:
     image: redis
     ports:
       - "${REDIS_PORT:-6380}:6379"
-    command: redis-server --requirepass ${REDIS_PASSWORD} --port 6379
+    environment:
+      - REDIS_PASSWORD=${REDIS_PASSWORD}
+    command: redis-server --requirepass "$${REDIS_PASSWORD}" --port 6379
     env_file:
       - ../.env
     networks:

--- a/script/developcompose/elk/docker-compose.yml
+++ b/script/developcompose/elk/docker-compose.yml
@@ -1,0 +1,32 @@
+services:
+
+  filebeat:
+    container_name: filebeat
+    hostname: filebeat
+    image: docker.elastic.co/beats/filebeat:8.15.0
+    networks:
+      - jabiseo-dev
+    volumes:
+      - "./filebeat.yml:/usr/share/filebeat/filebeat.yml"
+      - logsVolume:/logs
+
+  logstash:
+    container_name: logstash
+    hostname: logstash
+    image: opensearchproject/logstash-oss-with-opensearch-output-plugin:8.9.0
+    networks:
+      - jabiseo-dev
+    ports:
+      - 5044:5044
+    volumes:
+      - "./logstash.conf:/usr/share/logstash/pipeline/logstash.conf"
+
+volumes:
+  logsVolume:
+    external: true
+    name: logsVolume
+
+networks:
+  jabiseo-dev:
+    external: true
+    name: jabiseo-dev

--- a/script/developcompose/elk/filebeat.yml
+++ b/script/developcompose/elk/filebeat.yml
@@ -1,0 +1,8 @@
+filebeat.inputs:
+- type: log
+  enabled: true
+  paths:
+  - /logs/*.log
+
+output.logstash:
+ hosts: ["logstash:5044"]

--- a/script/developcompose/elk/logstash.conf
+++ b/script/developcompose/elk/logstash.conf
@@ -1,0 +1,15 @@
+input {
+  beats  {
+    port => 5044
+  }
+}
+
+output {        
+  opensearch {     
+    hosts => [""] ; OpenSearch URL
+    user => "" ; OpenSearch Username
+    password => ; // OpenSearch Password
+    index  => "logstash-logs-%{+YYYY.MM.dd}"
+    ecs_compatibility => disabled
+  }            
+}


### PR DESCRIPTION
## PR 변경된 내용
- 로컬 환경에서는 기본 콘솔 로그 설정 사용
- 개발 환경에서는 logback-dev.xml 파일로 설정
  - 일반 로그와 sql 로그를 각각 다른 파일에 로깅하도록 설정
  - Hibernate SQL 로그를 별도 파일에 기록하도록 설정하고, Hibernate의 나머지 로그는 OFF로 조정해 저장되지 않도록 설정
  - show_sql=true 설정은 콘솔 출력을 하는 설정이므로 개발 환경에서는 false로 설정
### 컨테이너 환경에서 elk 지침 및 자동화
- 로그 경로를 환경변수로 처리. 환경변수 최신화 필요
- CD 과정 중에 로그 관련 볼륨 (logsVolume) 추가
- script 폴더에 elk 관련 설정과 docker compose 파일 추가

## 추가 내용
- 로컬에서 jwt 유효 기간이 기본값과 동일하게 중복 삽입되어 삭제

## 참조
Closes #49 
