### PR TITLE
Feat(Problem): 시험, 과목, 자격증 테이블의 역정규화 테이블 추가

### DIFF
--- a/jabiseo-api/src/main/java/com/jabiseo/analysis/dto/FindVulnerableProblemsOfSubjectResponse.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/analysis/dto/FindVulnerableProblemsOfSubjectResponse.java
@@ -1,6 +1,0 @@
-package com.jabiseo.analysis.dto;
-
-public record FindVulnerableProblemsOfSubjectResponse(
-
-) {
-}

--- a/jabiseo-api/src/main/java/com/jabiseo/analysis/dto/FindVulnerableSubjectResponse.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/analysis/dto/FindVulnerableSubjectResponse.java
@@ -3,7 +3,7 @@ package com.jabiseo.analysis.dto;
 public record FindVulnerableSubjectResponse(
     Long subjectId,
     String subjectName,
-    int vulnerabilityScore
+    int vulnerableRate
 ) {
     public static FindVulnerableSubjectResponse from(VulnerableSubjectDto vulnerableSubjectDto) {
         return new FindVulnerableSubjectResponse(

--- a/jabiseo-api/src/main/java/com/jabiseo/problem/application/usecase/FindProblemsUseCase.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/problem/application/usecase/FindProblemsUseCase.java
@@ -1,7 +1,6 @@
 package com.jabiseo.problem.application.usecase;
 
 import com.jabiseo.certificate.domain.Certificate;
-import com.jabiseo.certificate.domain.Exam;
 import com.jabiseo.certificate.service.CertificateService;
 import com.jabiseo.problem.dto.CertificateResponse;
 import com.jabiseo.problem.dto.FindProblemsResponse;
@@ -31,23 +30,15 @@ public class FindProblemsUseCase {
         Certificate certificate = certificateService.getById(certificateId);
         certificateService.validateExamIdAndSubjectIds(certificate, examId, subjectIds);
 
-        List<ProblemWithBookmarkDetailQueryDto> problemWithBookmarkDetailQueryDtos = getProblemWithBookmarkDetailQueryDtos(memberId, examId, subjectIds, count, certificate);
+        List<ProblemWithBookmarkDetailQueryDto> dtos =
+                problemService.findProblemsByExamIdAndSubjectIds(memberId, examId, subjectIds, count);
 
-        List<ProblemsDetailResponse> problemsDetailResponses = problemWithBookmarkDetailQueryDtos.stream()
+        List<ProblemsDetailResponse> problemsDetailResponses = dtos.stream()
                 .map(ProblemsDetailResponse::from)
                 .toList();
 
         CertificateResponse certificateResponse = CertificateResponse.from(certificate);
 
         return FindProblemsResponse.of(certificateResponse, problemsDetailResponses);
-    }
-
-    private List<ProblemWithBookmarkDetailQueryDto> getProblemWithBookmarkDetailQueryDtos(Long memberId, Long examId, List<Long> subjectIds, int count, Certificate certificate) {
-        if (examId == null) {
-            List<Long> examIds = certificate.getExams().stream().map(Exam::getId).toList();
-            return problemService.findProblemsBySubjectId(memberId, examIds, subjectIds, count);
-        } else {
-            return problemService.findProblemsByExamIdAndSubjectIds(memberId, examId, subjectIds, count);
-        }
     }
 }

--- a/jabiseo-api/src/main/java/com/jabiseo/problem/application/usecase/FindProblemsUseCase.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/problem/application/usecase/FindProblemsUseCase.java
@@ -1,20 +1,18 @@
 package com.jabiseo.problem.application.usecase;
 
 import com.jabiseo.certificate.domain.Certificate;
-import com.jabiseo.certificate.domain.CertificateRepository;
-import com.jabiseo.certificate.exception.CertificateBusinessException;
-import com.jabiseo.certificate.exception.CertificateErrorCode;
-import com.jabiseo.problem.domain.ProblemRepository;
+import com.jabiseo.certificate.domain.Exam;
+import com.jabiseo.certificate.service.CertificateService;
 import com.jabiseo.problem.dto.CertificateResponse;
 import com.jabiseo.problem.dto.FindProblemsResponse;
 import com.jabiseo.problem.dto.ProblemWithBookmarkDetailQueryDto;
 import com.jabiseo.problem.dto.ProblemsDetailResponse;
+import com.jabiseo.problem.service.ProblemService;
 import jakarta.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Collections;
 import java.util.List;
 
 @Service
@@ -22,28 +20,18 @@ import java.util.List;
 @RequiredArgsConstructor
 public class FindProblemsUseCase {
 
-    private static final int MAX_PROBLEM_COUNT = 20;
-
-    private final CertificateRepository certificateRepository;
-    private final ProblemRepository problemRepository;
+    private final CertificateService certificateService;
+    private final ProblemService problemService;
 
     //memberId가 null일 경우 비회원이므로 bookmark 유무가 모두 false로 응답된다.
     //examId가 null일 경우 전체 시험을 대상으로 조회한다.
     public FindProblemsResponse execute(@Nullable Long memberId, Long certificateId,
                                         @Nullable Long examId, List<Long> subjectIds, int count) {
 
-        Certificate certificate = certificateRepository.findById(certificateId)
-                .orElseThrow(() -> new CertificateBusinessException(CertificateErrorCode.CERTIFICATE_NOT_FOUND));
-        certificate.validateExamIdAndSubjectIds(examId, subjectIds);
+        Certificate certificate = certificateService.getById(certificateId);
+        certificateService.validateExamIdAndSubjectIds(certificate, examId, subjectIds);
 
-        List<ProblemWithBookmarkDetailQueryDto> problemWithBookmarkDetailQueryDtos = subjectIds.stream()
-                .distinct()
-                .flatMap(subjectId -> {
-                    List<ProblemWithBookmarkDetailQueryDto> problems = problemRepository.findDetailByExamIdAndSubjectIdWithBookmark(memberId, examId, subjectId, MAX_PROBLEM_COUNT);
-                    Collections.shuffle(problems); // 문제 리스트를 랜덤으로 섞음
-                    return problems.stream().limit(count);
-                })
-                .toList();
+        List<ProblemWithBookmarkDetailQueryDto> problemWithBookmarkDetailQueryDtos = getProblemWithBookmarkDetailQueryDtos(memberId, examId, subjectIds, count, certificate);
 
         List<ProblemsDetailResponse> problemsDetailResponses = problemWithBookmarkDetailQueryDtos.stream()
                 .map(ProblemsDetailResponse::from)
@@ -52,5 +40,14 @@ public class FindProblemsUseCase {
         CertificateResponse certificateResponse = CertificateResponse.from(certificate);
 
         return FindProblemsResponse.of(certificateResponse, problemsDetailResponses);
+    }
+
+    private List<ProblemWithBookmarkDetailQueryDto> getProblemWithBookmarkDetailQueryDtos(Long memberId, Long examId, List<Long> subjectIds, int count, Certificate certificate) {
+        if (examId == null) {
+            List<Long> examIds = certificate.getExams().stream().map(Exam::getId).toList();
+            return problemService.findProblemsBySubjectId(memberId, examIds, subjectIds, count);
+        } else {
+            return problemService.findProblemsByExamIdAndSubjectIds(memberId, examId, subjectIds, count);
+        }
     }
 }

--- a/jabiseo-api/src/test/java/com/jabiseo/problem/application/usecase/FindProblemsUseCaseTest.java
+++ b/jabiseo-api/src/test/java/com/jabiseo/problem/application/usecase/FindProblemsUseCaseTest.java
@@ -1,17 +1,8 @@
 package com.jabiseo.problem.application.usecase;
 
 import com.jabiseo.certificate.domain.Certificate;
-import com.jabiseo.certificate.domain.CertificateRepository;
-import com.jabiseo.certificate.domain.Exam;
-import com.jabiseo.certificate.domain.Subject;
-import com.jabiseo.certificate.exception.CertificateBusinessException;
-import com.jabiseo.certificate.exception.CertificateErrorCode;
-import com.jabiseo.member.domain.Member;
-import com.jabiseo.problem.domain.Problem;
-import com.jabiseo.problem.domain.ProblemRepository;
-import com.jabiseo.problem.dto.FindProblemsResponse;
-import com.jabiseo.problem.dto.ProblemWithBookmarkDetailQueryDto;
-import com.jabiseo.problem.dto.ProblemsDetailResponse;
+import com.jabiseo.certificate.service.CertificateService;
+import com.jabiseo.problem.service.ProblemService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -19,20 +10,13 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 import static fixture.CertificateFixture.createCertificate;
 import static fixture.ExamFixture.createExam;
-import static fixture.MemberFixture.createMember;
-import static fixture.ProblemFixture.createProblem;
-import static fixture.ProblemWithBookmarkDetailQueryDtoFixture.createProblemWithBookmarkDetailQueryDto;
 import static fixture.SubjectFixture.createSubject;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
 @DisplayName("문제 세트 조회 테스트")
 @ExtendWith(MockitoExtension.class)
@@ -42,239 +26,54 @@ class FindProblemsUseCaseTest {
     FindProblemsUseCase sut;
 
     @Mock
-    CertificateRepository certificateRepository;
+    CertificateService certificateService;
 
     @Mock
-    ProblemRepository problemRepository;
+    ProblemService problemService;
 
     @Test
-    @DisplayName("로그인 유저가 시험 조건이 있는 문제 세트 조회를 성공한다.")
-    void givenLoginMemberWithIdsIncludeExamIdAndCount_whenFindingProblems_thenFindProblems() {
-        //given
+    @DisplayName("시험 조건이 없는 경우 findProblemsBySubjectId 메소드를 호출한다.")
+    void findProblemsBySubjectId() {
+        // given
+        List<Long> subjectIds = List.of(1L, 2L);
+        Long memberId = 1L;
         Long certificateId = 1L;
-        List<Long> subjectIds = List.of(2L, 3L);
-        Long examId = 4L;
-        List<Long> problemIds = List.of(5L, 6L, 7L);
-        Long memberId = 8L;
-        int count = 4;
+        List<Long> examIds = List.of(3L, 4L);
+        int count = 10;
 
         Certificate certificate = createCertificate(certificateId);
-        List<Subject> subjects = subjectIds.stream()
-                .map(id -> createSubject(id, certificate))
-                .toList();
-        Exam exam = createExam(examId, certificate);
-        List<Problem> problems = List.of(
-                createProblem(problemIds.get(0), certificate, exam, subjects.get(0)),
-                createProblem(problemIds.get(1), certificate, exam, subjects.get(1)),
-                createProblem(problemIds.get(2), certificate, exam, subjects.get(0))
-        );
-        Member member = createMember(memberId);
-        List<ProblemWithBookmarkDetailQueryDto> problemWithBookmarkDetailQueryDtos = problems.stream()
-                .map(problem -> createProblemWithBookmarkDetailQueryDto(problem, false))
-                .toList();
+        examIds.forEach(e -> createExam(e, certificate));
+        subjectIds.forEach(s -> createSubject(s, certificate));
+        given(certificateService.getById(certificateId)).willReturn(certificate);
 
-        int problemsToFetchCount = 20;
-        given(certificateRepository.findById(certificateId)).willReturn(Optional.of(certificate));
-        given(problemRepository.findDetailByExamIdAndSubjectIdWithBookmark(memberId, examId, subjectIds.get(0), problemsToFetchCount))
-                .willReturn(new ArrayList<>(List.of(problemWithBookmarkDetailQueryDtos.get(0), problemWithBookmarkDetailQueryDtos.get(2))));
-        given(problemRepository.findDetailByExamIdAndSubjectIdWithBookmark(memberId, examId, subjectIds.get(1), problemsToFetchCount))
-                .willReturn(new ArrayList<>(List.of(problemWithBookmarkDetailQueryDtos.get(1))));
+        // when
+        sut.execute(memberId, certificateId, null, subjectIds, count);
 
-        //when
-        FindProblemsResponse result = sut.execute(member.getId(), certificateId, examId, subjectIds, count);
-
-        //then
-        assertThat(result.certificateInfo().certificateId()).isEqualTo(certificateId);
-        assertThat(result.problems().stream()
-                .map(ProblemsDetailResponse::problemId))
-                .containsExactlyInAnyOrder(problemIds.get(0), problemIds.get(1), problemIds.get(2));
+        // then
+        verify(problemService).findProblemsBySubjectId(memberId, examIds, subjectIds, count);
     }
 
     @Test
-    @DisplayName("로그인 유저가 시험 조건이 없는 문제 세트 조회를 성공한다.")
-    void givenLoginMemberWithIdsExcludeExamIdAndCount_whenFindingProblems_thenFindProblems() {
-        //given
+    @DisplayName("시험 조건이 있는 경우 findProblemsByExamIdAndSubjectIds 메소드를 호출한다.")
+    void findProblemsByExamIdAndSubjectId() {
+        // given
+        List<Long> subjectIds = List.of(1L, 2L);
+        Long memberId = 1L;
         Long certificateId = 1L;
-        List<Long> subjectIds = List.of(2L, 3L);
-        List<Long> examIds = List.of(4L, 8L);
-        List<Long> problemIds = List.of(5L, 6L, 7L);
-        Long memberId = 8L;
-        int count = 4;
-
-        Certificate certificate = createCertificate(certificateId);
-        List<Subject> subjects = subjectIds.stream()
-                .map(id -> createSubject(id, certificate))
-                .toList();
-        List<Exam> exams = examIds.stream()
-                .map(id -> createExam(id, certificate))
-                .toList();
-        List<Problem> problems = List.of(
-                createProblem(problemIds.get(0), certificate, exams.get(0), subjects.get(0)),
-                createProblem(problemIds.get(1), certificate, exams.get(1), subjects.get(1)),
-                createProblem(problemIds.get(2), certificate, exams.get(1), subjects.get(0))
-        );
-        List<ProblemWithBookmarkDetailQueryDto> problemWithBookmarkDetailQueryDtos = problems.stream()
-                .map(problem -> createProblemWithBookmarkDetailQueryDto(problem, false))
-                .toList();
-
-        int problemsToFetchCount = 20;
-        given(certificateRepository.findById(certificateId)).willReturn(Optional.of(certificate));
-        given(problemRepository.findDetailByExamIdAndSubjectIdWithBookmark(memberId, null, subjectIds.get(0), problemsToFetchCount))
-                .willReturn(new ArrayList<>(List.of(problemWithBookmarkDetailQueryDtos.get(0), problemWithBookmarkDetailQueryDtos.get(2))));
-        given(problemRepository.findDetailByExamIdAndSubjectIdWithBookmark(memberId, null, subjectIds.get(1), problemsToFetchCount))
-                .willReturn(new ArrayList<>(List.of(problemWithBookmarkDetailQueryDtos.get(1))));
-
-        //when
-        FindProblemsResponse result = sut.execute(memberId, certificateId, null, subjectIds, count);
-
-        //then
-        assertThat(result.certificateInfo().certificateId()).isEqualTo(certificateId);
-        assertThat(result.problems().stream()
-                .map(ProblemsDetailResponse::problemId))
-                .containsExactlyInAnyOrder(problemIds.get(0), problemIds.get(1), problemIds.get(2));
-    }
-
-    @Test
-    @DisplayName("비로그인 유저가 시험 조건이 있는 문제 세트 조회를 성공한다.")
-    void givenNonLoginMemberWithIdsIncludeExamIdAndCount_whenFindingProblems_thenFindProblems() {
-        //given
-        Long certificateId = 1L;
-        List<Long> subjectIds = List.of(2L, 3L);
-        Long examId = 4L;
-        List<Long> problemIds = List.of(5L, 6L, 7L);
-        int count = 4;
-
-        Certificate certificate = createCertificate(certificateId);
-        List<Subject> subjects = subjectIds.stream()
-                .map(id -> createSubject(id, certificate))
-                .toList();
-        Exam exam = createExam(examId, certificate);
-        List<Problem> problems = List.of(
-                createProblem(problemIds.get(0), certificate, exam, subjects.get(0)),
-                createProblem(problemIds.get(1), certificate, exam, subjects.get(1)),
-                createProblem(problemIds.get(2), certificate, exam, subjects.get(0))
-        );
-        List<ProblemWithBookmarkDetailQueryDto> problemWithBookmarkDetailQueryDtos = problems.stream()
-                .map(problem -> createProblemWithBookmarkDetailQueryDto(problem, false))
-                .toList();
-
-        int problemsToFetchCount = 20;
-        given(certificateRepository.findById(certificateId)).willReturn(Optional.of(certificate));
-        given(problemRepository.findDetailByExamIdAndSubjectIdWithBookmark(null, examId, subjectIds.get(0), problemsToFetchCount))
-                .willReturn(new ArrayList<>(List.of(problemWithBookmarkDetailQueryDtos.get(0), problemWithBookmarkDetailQueryDtos.get(2))));
-        given(problemRepository.findDetailByExamIdAndSubjectIdWithBookmark(null, examId, subjectIds.get(1), problemsToFetchCount))
-                .willReturn(new ArrayList<>(List.of(problemWithBookmarkDetailQueryDtos.get(1))));
-
-        //when
-        FindProblemsResponse result = sut.execute(null, certificateId, examId, subjectIds, count);
-
-        //then
-        assertThat(result.certificateInfo().certificateId()).isEqualTo(certificateId);
-        assertThat(result.problems().stream()
-                .map(ProblemsDetailResponse::problemId))
-                .containsExactlyInAnyOrder(problemIds.get(0), problemIds.get(1), problemIds.get(2));
-    }
-
-    @Test
-    @DisplayName("비로그인 유저가 시험 조건이 없는 문제 세트 조회를 성공한다.")
-    void givenNonLoginMemberWithIdsExcludeExamIdAndCount_whenFindingProblems_thenFindProblems() {
-        //given
-        Long certificateId = 1L;
-        List<Long> subjectIds = List.of(2L, 3L);
-        List<Long> examIds = List.of(4L, 8L);
-        List<Long> problemIds = List.of(5L, 6L, 7L);
-        int count = 4;
-
-        Certificate certificate = createCertificate(certificateId);
-        List<Subject> subjects = subjectIds.stream()
-                .map(id -> createSubject(id, certificate))
-                .toList();
-        List<Exam> exams = examIds.stream()
-                .map(id -> createExam(id, certificate))
-                .toList();
-        List<Problem> problems = List.of(
-                createProblem(problemIds.get(0), certificate, exams.get(0), subjects.get(0)),
-                createProblem(problemIds.get(1), certificate, exams.get(1), subjects.get(1)),
-                createProblem(problemIds.get(2), certificate, exams.get(1), subjects.get(0))
-        );
-        List<ProblemWithBookmarkDetailQueryDto> problemWithBookmarkDetailQueryDtos = problems.stream()
-                .map(problem -> createProblemWithBookmarkDetailQueryDto(problem, false))
-                .toList();
-
-        int problemsToFetchCount = 20;
-        given(certificateRepository.findById(certificateId)).willReturn(Optional.of(certificate));
-        given(problemRepository.findDetailByExamIdAndSubjectIdWithBookmark(null, null, subjectIds.get(0), problemsToFetchCount))
-                .willReturn(new ArrayList<>(List.of(problemWithBookmarkDetailQueryDtos.get(0), problemWithBookmarkDetailQueryDtos.get(2))));
-        given(problemRepository.findDetailByExamIdAndSubjectIdWithBookmark(null, null, subjectIds.get(1), problemsToFetchCount))
-                .willReturn(new ArrayList<>(List.of(problemWithBookmarkDetailQueryDtos.get(1))));
-
-        //when
-        FindProblemsResponse result = sut.execute(null, certificateId, null, subjectIds, count);
-
-        //then
-        assertThat(result.certificateInfo().certificateId()).isEqualTo(certificateId);
-        assertThat(result.problems().stream()
-                .map(ProblemsDetailResponse::problemId))
-                .containsExactlyInAnyOrder(problemIds.get(0), problemIds.get(1), problemIds.get(2));
-    }
-
-    @Test
-    @DisplayName("문제 세트 조회 시 자격증이 존재하지 않는 경우 예외처리한다.")
-    void givenInvalidCertificate_whenFindingProblems_thenReturnError() {
-        //given
-        Long certificateId = 1L;
-        Long subjectId = 2L;
+        List<Long> examIds = List.of(3L, 4L);
         Long examId = 3L;
-        Long memberId = 4L;
-        int count = 4;
-
-        given(certificateRepository.findById(anyLong())).willReturn(Optional.empty());
-
-        //when & then
-        assertThatThrownBy(() -> sut.execute(memberId, certificateId, examId, List.of(subjectId), count))
-                .isInstanceOf(CertificateBusinessException.class)
-                .hasFieldOrPropertyWithValue("errorCode", CertificateErrorCode.CERTIFICATE_NOT_FOUND);
-    }
-
-    @Test
-    @DisplayName("문제 세트 조회 시 중복된 과목 ID가 요청되는 경우 중복제거 후 결과를 반환한다.")
-    void givenDuplicatedSubjectIds_whenFindingProblems_thenFindProblems() {
-        //given
-        Long certificateId = 1L;
-        List<Long> subjectIds = List.of(2L, 3L);
-        List<Long> requestSubjectIds = List.of(2L, 3L, 3L, 2L);
-        Long examId = 4L;
-        List<Long> problemIds = List.of(5L, 6L, 7L);
-        int count = 4;
+        int count = 10;
 
         Certificate certificate = createCertificate(certificateId);
-        List<Subject> subjects = subjectIds.stream()
-                .map(id -> createSubject(id, certificate))
-                .toList();
-        Exam exam = createExam(examId, certificate);
-        List<Problem> problems = List.of(
-                createProblem(problemIds.get(0), certificate, exam, subjects.get(0)),
-                createProblem(problemIds.get(1), certificate, exam, subjects.get(1)),
-                createProblem(problemIds.get(2), certificate, exam, subjects.get(0))
-        );
-        List<ProblemWithBookmarkDetailQueryDto> problemWithBookmarkDetailQueryDtos = problems.stream()
-                .map(problem -> createProblemWithBookmarkDetailQueryDto(problem, false))
-                .toList();
+        examIds.forEach(e -> createExam(e, certificate));
+        subjectIds.forEach(s -> createSubject(s, certificate));
+        given(certificateService.getById(certificateId)).willReturn(certificate);
 
-        int problemsToFetchCount = 20;
-        given(certificateRepository.findById(certificateId)).willReturn(Optional.of(certificate));
-        given(problemRepository.findDetailByExamIdAndSubjectIdWithBookmark(null, examId, subjectIds.get(0), problemsToFetchCount))
-                .willReturn(new ArrayList<>(List.of(problemWithBookmarkDetailQueryDtos.get(0), problemWithBookmarkDetailQueryDtos.get(2))));
-        given(problemRepository.findDetailByExamIdAndSubjectIdWithBookmark(null, examId, subjectIds.get(1), problemsToFetchCount))
-                .willReturn(new ArrayList<>(List.of(problemWithBookmarkDetailQueryDtos.get(1))));
+        // when
+        sut.execute(memberId, certificateId, examId, subjectIds, count);
 
-        //when
-        FindProblemsResponse result = sut.execute(null, certificateId, examId, requestSubjectIds, count);
-
-        //then
-        assertThat(result.certificateInfo().certificateId()).isEqualTo(certificateId);
-        assertThat(result.problems().stream()
-                .map(ProblemsDetailResponse::problemId))
-                .containsExactlyInAnyOrder(problemIds.get(0), problemIds.get(1), problemIds.get(2));
+        // then
+        verify(problemService).findProblemsByExamIdAndSubjectIds(memberId, examId, subjectIds, count);
     }
+
 }

--- a/jabiseo-api/src/test/java/com/jabiseo/problem/application/usecase/FindProblemsUseCaseTest.java
+++ b/jabiseo-api/src/test/java/com/jabiseo/problem/application/usecase/FindProblemsUseCaseTest.java
@@ -11,6 +11,7 @@ import com.jabiseo.problem.domain.Problem;
 import com.jabiseo.problem.domain.ProblemRepository;
 import com.jabiseo.problem.dto.FindProblemsResponse;
 import com.jabiseo.problem.dto.ProblemWithBookmarkDetailQueryDto;
+import com.jabiseo.problem.dto.ProblemsDetailResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,6 +19,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -71,20 +73,21 @@ class FindProblemsUseCaseTest {
                 .map(problem -> createProblemWithBookmarkDetailQueryDto(problem, false))
                 .toList();
 
+        int problemsToFetchCount = 20;
         given(certificateRepository.findById(certificateId)).willReturn(Optional.of(certificate));
-        given(problemRepository.findDetailByExamIdAndSubjectIdWithBookmark(memberId, examId, subjectIds.get(0), count))
-                .willReturn(List.of(problemWithBookmarkDetailQueryDtos.get(0), problemWithBookmarkDetailQueryDtos.get(2)));
-        given(problemRepository.findDetailByExamIdAndSubjectIdWithBookmark(memberId, examId, subjectIds.get(1), count))
-                .willReturn(List.of(problemWithBookmarkDetailQueryDtos.get(1)));
+        given(problemRepository.findDetailByExamIdAndSubjectIdWithBookmark(memberId, examId, subjectIds.get(0), problemsToFetchCount))
+                .willReturn(new ArrayList<>(List.of(problemWithBookmarkDetailQueryDtos.get(0), problemWithBookmarkDetailQueryDtos.get(2))));
+        given(problemRepository.findDetailByExamIdAndSubjectIdWithBookmark(memberId, examId, subjectIds.get(1), problemsToFetchCount))
+                .willReturn(new ArrayList<>(List.of(problemWithBookmarkDetailQueryDtos.get(1))));
 
         //when
         FindProblemsResponse result = sut.execute(member.getId(), certificateId, examId, subjectIds, count);
 
         //then
         assertThat(result.certificateInfo().certificateId()).isEqualTo(certificateId);
-        assertThat(result.problems().get(0).problemId()).isEqualTo(problemIds.get(0));
-        assertThat(result.problems().get(1).problemId()).isEqualTo(problemIds.get(2));
-        assertThat(result.problems().get(2).problemId()).isEqualTo(problemIds.get(1));
+        assertThat(result.problems().stream()
+                .map(ProblemsDetailResponse::problemId))
+                .containsExactlyInAnyOrder(problemIds.get(0), problemIds.get(1), problemIds.get(2));
     }
 
     @Test
@@ -114,20 +117,21 @@ class FindProblemsUseCaseTest {
                 .map(problem -> createProblemWithBookmarkDetailQueryDto(problem, false))
                 .toList();
 
+        int problemsToFetchCount = 20;
         given(certificateRepository.findById(certificateId)).willReturn(Optional.of(certificate));
-        given(problemRepository.findDetailByExamIdAndSubjectIdWithBookmark(memberId, null, subjectIds.get(0), count))
-                .willReturn(List.of(problemWithBookmarkDetailQueryDtos.get(0), problemWithBookmarkDetailQueryDtos.get(2)));
-        given(problemRepository.findDetailByExamIdAndSubjectIdWithBookmark(memberId, null, subjectIds.get(1), count))
-                .willReturn(List.of(problemWithBookmarkDetailQueryDtos.get(1)));
+        given(problemRepository.findDetailByExamIdAndSubjectIdWithBookmark(memberId, null, subjectIds.get(0), problemsToFetchCount))
+                .willReturn(new ArrayList<>(List.of(problemWithBookmarkDetailQueryDtos.get(0), problemWithBookmarkDetailQueryDtos.get(2))));
+        given(problemRepository.findDetailByExamIdAndSubjectIdWithBookmark(memberId, null, subjectIds.get(1), problemsToFetchCount))
+                .willReturn(new ArrayList<>(List.of(problemWithBookmarkDetailQueryDtos.get(1))));
 
         //when
         FindProblemsResponse result = sut.execute(memberId, certificateId, null, subjectIds, count);
 
         //then
         assertThat(result.certificateInfo().certificateId()).isEqualTo(certificateId);
-        assertThat(result.problems().get(0).problemId()).isEqualTo(problemIds.get(0));
-        assertThat(result.problems().get(1).problemId()).isEqualTo(problemIds.get(2));
-        assertThat(result.problems().get(2).problemId()).isEqualTo(problemIds.get(1));
+        assertThat(result.problems().stream()
+                .map(ProblemsDetailResponse::problemId))
+                .containsExactlyInAnyOrder(problemIds.get(0), problemIds.get(1), problemIds.get(2));
     }
 
     @Test
@@ -154,20 +158,21 @@ class FindProblemsUseCaseTest {
                 .map(problem -> createProblemWithBookmarkDetailQueryDto(problem, false))
                 .toList();
 
+        int problemsToFetchCount = 20;
         given(certificateRepository.findById(certificateId)).willReturn(Optional.of(certificate));
-        given(problemRepository.findDetailByExamIdAndSubjectIdWithBookmark(null, examId, subjectIds.get(0), count))
-                .willReturn(List.of(problemWithBookmarkDetailQueryDtos.get(0), problemWithBookmarkDetailQueryDtos.get(2)));
-        given(problemRepository.findDetailByExamIdAndSubjectIdWithBookmark(null, examId, subjectIds.get(1), count))
-                .willReturn(List.of(problemWithBookmarkDetailQueryDtos.get(1)));
+        given(problemRepository.findDetailByExamIdAndSubjectIdWithBookmark(null, examId, subjectIds.get(0), problemsToFetchCount))
+                .willReturn(new ArrayList<>(List.of(problemWithBookmarkDetailQueryDtos.get(0), problemWithBookmarkDetailQueryDtos.get(2))));
+        given(problemRepository.findDetailByExamIdAndSubjectIdWithBookmark(null, examId, subjectIds.get(1), problemsToFetchCount))
+                .willReturn(new ArrayList<>(List.of(problemWithBookmarkDetailQueryDtos.get(1))));
 
         //when
         FindProblemsResponse result = sut.execute(null, certificateId, examId, subjectIds, count);
 
         //then
         assertThat(result.certificateInfo().certificateId()).isEqualTo(certificateId);
-        assertThat(result.problems().get(0).problemId()).isEqualTo(problemIds.get(0));
-        assertThat(result.problems().get(1).problemId()).isEqualTo(problemIds.get(2));
-        assertThat(result.problems().get(2).problemId()).isEqualTo(problemIds.get(1));
+        assertThat(result.problems().stream()
+                .map(ProblemsDetailResponse::problemId))
+                .containsExactlyInAnyOrder(problemIds.get(0), problemIds.get(1), problemIds.get(2));
     }
 
     @Test
@@ -196,20 +201,21 @@ class FindProblemsUseCaseTest {
                 .map(problem -> createProblemWithBookmarkDetailQueryDto(problem, false))
                 .toList();
 
+        int problemsToFetchCount = 20;
         given(certificateRepository.findById(certificateId)).willReturn(Optional.of(certificate));
-        given(problemRepository.findDetailByExamIdAndSubjectIdWithBookmark(null, null, subjectIds.get(0), count))
-                .willReturn(List.of(problemWithBookmarkDetailQueryDtos.get(0), problemWithBookmarkDetailQueryDtos.get(2)));
-        given(problemRepository.findDetailByExamIdAndSubjectIdWithBookmark(null, null, subjectIds.get(1), count))
-                .willReturn(List.of(problemWithBookmarkDetailQueryDtos.get(1)));
+        given(problemRepository.findDetailByExamIdAndSubjectIdWithBookmark(null, null, subjectIds.get(0), problemsToFetchCount))
+                .willReturn(new ArrayList<>(List.of(problemWithBookmarkDetailQueryDtos.get(0), problemWithBookmarkDetailQueryDtos.get(2))));
+        given(problemRepository.findDetailByExamIdAndSubjectIdWithBookmark(null, null, subjectIds.get(1), problemsToFetchCount))
+                .willReturn(new ArrayList<>(List.of(problemWithBookmarkDetailQueryDtos.get(1))));
 
         //when
         FindProblemsResponse result = sut.execute(null, certificateId, null, subjectIds, count);
 
         //then
         assertThat(result.certificateInfo().certificateId()).isEqualTo(certificateId);
-        assertThat(result.problems().get(0).problemId()).isEqualTo(problemIds.get(0));
-        assertThat(result.problems().get(1).problemId()).isEqualTo(problemIds.get(2));
-        assertThat(result.problems().get(2).problemId()).isEqualTo(problemIds.get(1));
+        assertThat(result.problems().stream()
+                .map(ProblemsDetailResponse::problemId))
+                .containsExactlyInAnyOrder(problemIds.get(0), problemIds.get(1), problemIds.get(2));
     }
 
     @Test
@@ -255,19 +261,20 @@ class FindProblemsUseCaseTest {
                 .map(problem -> createProblemWithBookmarkDetailQueryDto(problem, false))
                 .toList();
 
+        int problemsToFetchCount = 20;
         given(certificateRepository.findById(certificateId)).willReturn(Optional.of(certificate));
-        given(problemRepository.findDetailByExamIdAndSubjectIdWithBookmark(null, examId, subjectIds.get(0), count))
-                .willReturn(List.of(problemWithBookmarkDetailQueryDtos.get(0), problemWithBookmarkDetailQueryDtos.get(2)));
-        given(problemRepository.findDetailByExamIdAndSubjectIdWithBookmark(null, examId, subjectIds.get(1), count))
-                .willReturn(List.of(problemWithBookmarkDetailQueryDtos.get(1)));
+        given(problemRepository.findDetailByExamIdAndSubjectIdWithBookmark(null, examId, subjectIds.get(0), problemsToFetchCount))
+                .willReturn(new ArrayList<>(List.of(problemWithBookmarkDetailQueryDtos.get(0), problemWithBookmarkDetailQueryDtos.get(2))));
+        given(problemRepository.findDetailByExamIdAndSubjectIdWithBookmark(null, examId, subjectIds.get(1), problemsToFetchCount))
+                .willReturn(new ArrayList<>(List.of(problemWithBookmarkDetailQueryDtos.get(1))));
 
         //when
         FindProblemsResponse result = sut.execute(null, certificateId, examId, requestSubjectIds, count);
 
         //then
         assertThat(result.certificateInfo().certificateId()).isEqualTo(certificateId);
-        assertThat(result.problems().get(0).problemId()).isEqualTo(problemIds.get(0));
-        assertThat(result.problems().get(1).problemId()).isEqualTo(problemIds.get(2));
-        assertThat(result.problems().get(2).problemId()).isEqualTo(problemIds.get(1));
+        assertThat(result.problems().stream()
+                .map(ProblemsDetailResponse::problemId))
+                .containsExactlyInAnyOrder(problemIds.get(0), problemIds.get(1), problemIds.get(2));
     }
 }

--- a/jabiseo-api/src/test/java/com/jabiseo/problem/application/usecase/FindProblemsUseCaseTest.java
+++ b/jabiseo-api/src/test/java/com/jabiseo/problem/application/usecase/FindProblemsUseCaseTest.java
@@ -72,9 +72,9 @@ class FindProblemsUseCaseTest {
                 .toList();
 
         given(certificateRepository.findById(certificateId)).willReturn(Optional.of(certificate));
-        given(problemRepository.findDetailRandomByExamIdAndSubjectIdWithBookmark(memberId, examId, subjectIds.get(0), count))
+        given(problemRepository.findDetailByExamIdAndSubjectIdWithBookmark(memberId, examId, subjectIds.get(0), count))
                 .willReturn(List.of(problemWithBookmarkDetailQueryDtos.get(0), problemWithBookmarkDetailQueryDtos.get(2)));
-        given(problemRepository.findDetailRandomByExamIdAndSubjectIdWithBookmark(memberId, examId, subjectIds.get(1), count))
+        given(problemRepository.findDetailByExamIdAndSubjectIdWithBookmark(memberId, examId, subjectIds.get(1), count))
                 .willReturn(List.of(problemWithBookmarkDetailQueryDtos.get(1)));
 
         //when
@@ -115,9 +115,9 @@ class FindProblemsUseCaseTest {
                 .toList();
 
         given(certificateRepository.findById(certificateId)).willReturn(Optional.of(certificate));
-        given(problemRepository.findDetailRandomByExamIdAndSubjectIdWithBookmark(memberId, null, subjectIds.get(0), count))
+        given(problemRepository.findDetailByExamIdAndSubjectIdWithBookmark(memberId, null, subjectIds.get(0), count))
                 .willReturn(List.of(problemWithBookmarkDetailQueryDtos.get(0), problemWithBookmarkDetailQueryDtos.get(2)));
-        given(problemRepository.findDetailRandomByExamIdAndSubjectIdWithBookmark(memberId, null, subjectIds.get(1), count))
+        given(problemRepository.findDetailByExamIdAndSubjectIdWithBookmark(memberId, null, subjectIds.get(1), count))
                 .willReturn(List.of(problemWithBookmarkDetailQueryDtos.get(1)));
 
         //when
@@ -155,9 +155,9 @@ class FindProblemsUseCaseTest {
                 .toList();
 
         given(certificateRepository.findById(certificateId)).willReturn(Optional.of(certificate));
-        given(problemRepository.findDetailRandomByExamIdAndSubjectIdWithBookmark(null, examId, subjectIds.get(0), count))
+        given(problemRepository.findDetailByExamIdAndSubjectIdWithBookmark(null, examId, subjectIds.get(0), count))
                 .willReturn(List.of(problemWithBookmarkDetailQueryDtos.get(0), problemWithBookmarkDetailQueryDtos.get(2)));
-        given(problemRepository.findDetailRandomByExamIdAndSubjectIdWithBookmark(null, examId, subjectIds.get(1), count))
+        given(problemRepository.findDetailByExamIdAndSubjectIdWithBookmark(null, examId, subjectIds.get(1), count))
                 .willReturn(List.of(problemWithBookmarkDetailQueryDtos.get(1)));
 
         //when
@@ -197,9 +197,9 @@ class FindProblemsUseCaseTest {
                 .toList();
 
         given(certificateRepository.findById(certificateId)).willReturn(Optional.of(certificate));
-        given(problemRepository.findDetailRandomByExamIdAndSubjectIdWithBookmark(null, null, subjectIds.get(0), count))
+        given(problemRepository.findDetailByExamIdAndSubjectIdWithBookmark(null, null, subjectIds.get(0), count))
                 .willReturn(List.of(problemWithBookmarkDetailQueryDtos.get(0), problemWithBookmarkDetailQueryDtos.get(2)));
-        given(problemRepository.findDetailRandomByExamIdAndSubjectIdWithBookmark(null, null, subjectIds.get(1), count))
+        given(problemRepository.findDetailByExamIdAndSubjectIdWithBookmark(null, null, subjectIds.get(1), count))
                 .willReturn(List.of(problemWithBookmarkDetailQueryDtos.get(1)));
 
         //when
@@ -256,9 +256,9 @@ class FindProblemsUseCaseTest {
                 .toList();
 
         given(certificateRepository.findById(certificateId)).willReturn(Optional.of(certificate));
-        given(problemRepository.findDetailRandomByExamIdAndSubjectIdWithBookmark(null, examId, subjectIds.get(0), count))
+        given(problemRepository.findDetailByExamIdAndSubjectIdWithBookmark(null, examId, subjectIds.get(0), count))
                 .willReturn(List.of(problemWithBookmarkDetailQueryDtos.get(0), problemWithBookmarkDetailQueryDtos.get(2)));
-        given(problemRepository.findDetailRandomByExamIdAndSubjectIdWithBookmark(null, examId, subjectIds.get(1), count))
+        given(problemRepository.findDetailByExamIdAndSubjectIdWithBookmark(null, examId, subjectIds.get(1), count))
                 .willReturn(List.of(problemWithBookmarkDetailQueryDtos.get(1)));
 
         //when

--- a/jabiseo-domain/src/main/java/com/jabiseo/analysis/service/AnalysisService.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/analysis/service/AnalysisService.java
@@ -27,10 +27,10 @@ import static java.time.LocalDateTime.now;
 public class AnalysisService {
 
     private static final int DEFAULT_TAG_COUNT = 5;
-    // 최근 1년간의 학습 데이터만 사용
-    private static final int YEARS_OF_ANALYSIS = 1;
-    // 추천 모의고사, 취약 문제 조회는 50문제 제공
-    private static final int DEFAULT_VULNERABLE_PROBLEM_COUNT = 50;
+    // 과목의 취약 문제 조회는 50문제 제공
+    private static final int DEFAULT_VULNERABLE_PROBLEM_OF_SUBJECT_COUNT = 50;
+    // 추천 모의고사 문제는 100문제 제공
+    private static final int DEFAULT_RECOMMENDATION_PROBLEM_COUNT = 100;
 
     private final ProblemSolvingRepository problemSolvingRepository;
     private final VulnerabilityProvider vulnerabilityProvider;
@@ -47,12 +47,12 @@ public class AnalysisService {
 
     public List<Long> findVulnerableProblemIdsOfSubject(Member member, Certificate certificate, Long subjectId) {
         List<Float> vulnerableVector = findVulnerableVector(member, certificate);
-        return vulnerabilityProvider.findVulnerableProblemIdsOfSubject(vulnerableVector, certificate.getId(), subjectId, DEFAULT_VULNERABLE_PROBLEM_COUNT);
+        return vulnerabilityProvider.findVulnerableProblemIdsOfSubject(vulnerableVector, certificate.getId(), subjectId, DEFAULT_VULNERABLE_PROBLEM_OF_SUBJECT_COUNT);
     }
 
     public List<Long> findVulnerableProblems(Member member, Certificate certificate) {
         List<Float> vulnerableVector = findVulnerableVector(member, certificate);
-        return vulnerabilityProvider.findVulnerableProblems(vulnerableVector, certificate.getId(), DEFAULT_VULNERABLE_PROBLEM_COUNT);
+        return vulnerabilityProvider.findVulnerableProblems(vulnerableVector, certificate.getId(), DEFAULT_RECOMMENDATION_PROBLEM_COUNT);
     }
 
     List<Float> findVulnerableVector(Member member, Certificate certificate) {

--- a/jabiseo-domain/src/main/java/com/jabiseo/certificate/service/CertificateService.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/certificate/service/CertificateService.java
@@ -1,0 +1,26 @@
+package com.jabiseo.certificate.service;
+
+import com.jabiseo.certificate.domain.Certificate;
+import com.jabiseo.certificate.domain.CertificateRepository;
+import com.jabiseo.certificate.exception.CertificateBusinessException;
+import com.jabiseo.certificate.exception.CertificateErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CertificateService {
+
+    private final CertificateRepository certificateRepository;
+
+    public Certificate getById(Long certificateId) {
+        return certificateRepository.findById(certificateId)
+                .orElseThrow(() -> new CertificateBusinessException(CertificateErrorCode.CERTIFICATE_NOT_FOUND));
+    }
+
+    public void validateExamIdAndSubjectIds(Certificate certificate, Long examId, List<Long> subjectIds) {
+        certificate.validateExamIdAndSubjectIds(examId, subjectIds);
+    }
+}

--- a/jabiseo-domain/src/main/java/com/jabiseo/problem/domain/Problem.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/problem/domain/Problem.java
@@ -49,6 +49,10 @@ public class Problem {
     @JoinColumn(name = "subject_id", foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
     private Subject subject;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "problem_info_id", foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
+    private ProblemInfo problemInfo;
+
     public List<String> getChoices() {
         return List.of(choice1, choice2, choice3, choice4);
     }

--- a/jabiseo-domain/src/main/java/com/jabiseo/problem/domain/Problem.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/problem/domain/Problem.java
@@ -57,8 +57,8 @@ public class Problem {
         return List.of(choice1, choice2, choice3, choice4);
     }
 
-    private Problem(String description, String choice1, String choice2, String choice3, String choice4,
-                    int answerNumber, String solution, int sequence, Certificate certificate, Exam exam, Subject subject) {
+    private Problem(String description, String choice1, String choice2, String choice3, String choice4, int answerNumber,
+                    String solution, int sequence, Certificate certificate, Exam exam, Subject subject, ProblemInfo problemInfo) {
         this.description = description;
         this.choice1 = choice1;
         this.choice2 = choice2;
@@ -70,12 +70,13 @@ public class Problem {
         this.certificate = certificate;
         this.exam = exam;
         this.subject = subject;
+        this.problemInfo = problemInfo;
     }
 
-    public static Problem of(String description, String choice1, String choice2, String choice3, String choice4,
-                             int answerNumber, String solution, int sequence, Certificate certificate, Exam exam, Subject subject) {
+    public static Problem of(String description, String choice1, String choice2, String choice3, String choice4, int answerNumber,
+                             String solution, int sequence, Certificate certificate, Exam exam, Subject subject, ProblemInfo problemInfo) {
         return new Problem(description, choice1, choice2, choice3, choice4,
-                answerNumber, solution, sequence, certificate, exam, subject);
+                answerNumber, solution, sequence, certificate, exam, subject, problemInfo);
     }
 
     public void validateProblemInCertificate(Certificate certificate) {

--- a/jabiseo-domain/src/main/java/com/jabiseo/problem/domain/ProblemInfo.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/problem/domain/ProblemInfo.java
@@ -33,4 +33,22 @@ public class ProblemInfo {
 
     private int subjectSequence;
 
+    private ProblemInfo(Long certificateId, String certificateName, Long examId, String examDescription,
+                       int examYear, int examYearRound, Long subjectId, String subjectName, int subjectSequence) {
+        this.certificateId = certificateId;
+        this.certificateName = certificateName;
+        this.examId = examId;
+        this.examDescription = examDescription;
+        this.examYear = examYear;
+        this.examYearRound = examYearRound;
+        this.subjectId = subjectId;
+        this.subjectName = subjectName;
+        this.subjectSequence = subjectSequence;
+    }
+
+    public static ProblemInfo of(Long certificateId, String certificateName, Long examId, String examDescription,
+                                 int examYear, int examYearRound, Long subjectId, String subjectName, int subjectSequence) {
+        return new ProblemInfo(certificateId, certificateName, examId, examDescription, examYear, examYearRound, subjectId, subjectName, subjectSequence);
+    }
+
 }

--- a/jabiseo-domain/src/main/java/com/jabiseo/problem/domain/ProblemInfo.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/problem/domain/ProblemInfo.java
@@ -1,0 +1,36 @@
+package com.jabiseo.problem.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+public class ProblemInfo {
+
+    @Id
+    @Column(name = "problem_info_id")
+    private Long id;
+
+    private Long certificateId;
+
+    private String certificateName;
+
+    private Long examId;
+
+    private String examDescription;
+
+    private int examYear;
+
+    private int examYearRound;
+
+    private Long subjectId;
+
+    private String subjectName;
+
+    private int subjectSequence;
+
+}

--- a/jabiseo-domain/src/main/java/com/jabiseo/problem/domain/querydsl/ProblemRepositoryCustom.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/problem/domain/querydsl/ProblemRepositoryCustom.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 public interface ProblemRepositoryCustom {
 
-    List<ProblemWithBookmarkDetailQueryDto> findDetailRandomByExamIdAndSubjectIdWithBookmark(Long memberId, Long examId, Long subjectId, int count);
+    List<ProblemWithBookmarkDetailQueryDto> findDetailByExamIdAndSubjectIdWithBookmark(Long memberId, Long examId, Long subjectId, int count);
 
     List<ProblemWithBookmarkDetailQueryDto> findDetailByIdsInWithBookmark(Long memberId, List<Long> problemIds);
 

--- a/jabiseo-domain/src/main/java/com/jabiseo/problem/domain/querydsl/ProblemRepositoryCustom.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/problem/domain/querydsl/ProblemRepositoryCustom.java
@@ -11,6 +11,8 @@ public interface ProblemRepositoryCustom {
 
     List<ProblemWithBookmarkDetailQueryDto> findDetailByExamIdAndSubjectIdWithBookmark(Long memberId, Long examId, Long subjectId, int count);
 
+    List<ProblemWithBookmarkDetailQueryDto> findDetailBySubjectIdWithBookmark(Long memberId, Long subjectId);
+
     List<ProblemWithBookmarkDetailQueryDto> findDetailByIdsInWithBookmark(Long memberId, List<Long> problemIds);
 
     ProblemWithBookmarkDetailQueryDto findDetailByIdWithBookmark(Long memberId, Long problemId);

--- a/jabiseo-domain/src/main/java/com/jabiseo/problem/domain/querydsl/ProblemRepositoryCustomImpl.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/problem/domain/querydsl/ProblemRepositoryCustomImpl.java
@@ -5,6 +5,7 @@ import com.jabiseo.problem.dto.ProblemWithBookmarkSummaryQueryDto;
 import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -14,8 +15,6 @@ import org.springframework.data.support.PageableExecutionUtils;
 
 import java.util.List;
 
-import static com.jabiseo.certificate.domain.QExam.exam;
-import static com.jabiseo.certificate.domain.QSubject.subject;
 import static com.jabiseo.problem.domain.QBookmark.bookmark;
 import static com.jabiseo.problem.domain.QProblem.problem;
 import static com.jabiseo.problem.domain.QProblemInfo.problemInfo;
@@ -49,7 +48,7 @@ public class ProblemRepositoryCustomImpl implements ProblemRepositoryCustom {
                 )
                 .from(problem)
                 .join(problem.problemInfo, problemInfo)
-                .leftJoin(bookmark).on(bookmark.problem.id.eq(problem.id).and(bookmark.member.id.eq(memberId)))
+                .leftJoin(bookmark).on(bookmark.problem.id.eq(problem.id).and(memberIdExistsOrFalse(memberId)))
                 .where(examIdEq(examId), subjectIdEq(subjectId))
                 .limit(count)
                 .fetch();
@@ -79,7 +78,7 @@ public class ProblemRepositoryCustomImpl implements ProblemRepositoryCustom {
                 )
                 .from(problem)
                 .join(problem.problemInfo, problemInfo)
-                .leftJoin(bookmark).on(bookmark.problem.id.eq(problem.id).and(bookmark.member.id.eq(memberId)))
+                .leftJoin(bookmark).on(bookmark.problem.id.eq(problem.id).and(memberIdExistsOrFalse(memberId)))
                 .where(problem.id.in(problemIds))
                 .fetch();
     }
@@ -93,16 +92,16 @@ public class ProblemRepositoryCustomImpl implements ProblemRepositoryCustom {
                                 problem.id.as("problemId"),
                                 problem.description,
                                 bookmark.id.isNotNull().as("isBookmark"),
-                                exam.id.as("examId"),
-                                exam.description.as("examDescription"),
-                                subject.id.as("subjectId"),
-                                subject.name.as("subjectName"),
-                                subject.sequence.as("subjectSequence")
+                                problemInfo.examId.as("examId"),
+                                problemInfo.examDescription.as("examDescription"),
+                                problemInfo.subjectId.as("subjectId"),
+                                problemInfo.subjectName.as("subjectName"),
+                                problemInfo.subjectSequence.as("subjectSequence")
                         )
                 )
                 .from(problem)
                 .join(problem.problemInfo, problemInfo)
-                .leftJoin(bookmark).on(bookmark.problem.id.eq(problem.id).and(bookmark.member.id.eq(memberId)))
+                .leftJoin(bookmark).on(bookmark.problem.id.eq(problem.id).and(memberIdExistsOrFalse(memberId)))
                 .where(memberIdEq(memberId), examIdEq(examId), subjectIdsIn(subjectIds))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
@@ -142,7 +141,7 @@ public class ProblemRepositoryCustomImpl implements ProblemRepositoryCustom {
                 )
                 .from(problem)
                 .join(problem.problemInfo, problemInfo)
-                .leftJoin(bookmark).on(bookmark.problem.id.eq(problem.id).and(bookmark.member.id.eq(memberId)))
+                .leftJoin(bookmark).on(bookmark.problem.id.eq(problem.id).and(memberIdExistsOrFalse(memberId)))
                 .where(problem.id.eq(problemId))
                 .fetchOne();
     }
@@ -156,16 +155,16 @@ public class ProblemRepositoryCustomImpl implements ProblemRepositoryCustom {
                                 problem.id.as("problemId"),
                                 problem.description,
                                 bookmark.id.isNotNull().as("isBookmark"),
-                                exam.id.as("examId"),
-                                exam.description.as("examDescription"),
-                                subject.id.as("subjectId"),
-                                subject.name.as("subjectName"),
-                                subject.sequence.as("subjectSequence")
+                                problemInfo.examId.as("examId"),
+                                problemInfo.examDescription.as("examDescription"),
+                                problemInfo.subjectId.as("subjectId"),
+                                problemInfo.subjectName.as("subjectName"),
+                                problemInfo.subjectSequence.as("subjectSequence")
                         )
                 )
                 .from(problem)
                 .join(problem.problemInfo, problemInfo)
-                .leftJoin(bookmark).on(bookmark.problem.id.eq(problem.id).and(bookmark.member.id.eq(memberId)))
+                .leftJoin(bookmark).on(bookmark.problem.id.eq(problem.id).and(memberIdExistsOrFalse(memberId)))
                 .where(problem.id.in(problemIds))
                 .fetch();
     }
@@ -184,5 +183,9 @@ public class ProblemRepositoryCustomImpl implements ProblemRepositoryCustom {
 
     private BooleanExpression memberIdEq(Long memberId) {
         return memberId != null ? bookmark.member.id.eq(memberId) : null;
+    }
+
+    private BooleanExpression memberIdExistsOrFalse(Long memberId) {
+        return memberId != null ? bookmark.member.id.eq(memberId) : Expressions.FALSE;
     }
 }

--- a/jabiseo-domain/src/main/java/com/jabiseo/problem/domain/querydsl/ProblemRepositoryCustomImpl.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/problem/domain/querydsl/ProblemRepositoryCustomImpl.java
@@ -33,6 +33,13 @@ public class ProblemRepositoryCustomImpl implements ProblemRepositoryCustom {
     }
 
     @Override
+    public List<ProblemWithBookmarkDetailQueryDto> findDetailBySubjectIdWithBookmark(Long memberId, Long subjectId) {
+        return makeProblemWithBookmarkDetailQuery(memberId)
+                .where(subjectIdEq(subjectId))
+                .fetch();
+    }
+
+    @Override
     public List<ProblemWithBookmarkDetailQueryDto> findDetailByIdsInWithBookmark(Long memberId, List<Long> problemIds) {
         return makeProblemWithBookmarkDetailQuery(memberId)
                 .where(problem.id.in(problemIds))

--- a/jabiseo-domain/src/main/java/com/jabiseo/problem/service/ProblemService.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/problem/service/ProblemService.java
@@ -9,12 +9,15 @@ import com.jabiseo.problem.exception.ProblemErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class ProblemService {
 
+    private static final int MAX_PROBLEM_COUNT = 20;
     private static final int SIMILAR_PROBLEM_COUNT = 3;
 
     private final ProblemRepository problemRepository;
@@ -33,4 +36,37 @@ public class ProblemService {
     public List<ProblemWithBookmarkDetailQueryDto> findProblemsById(Long memberId, List<Long> problemIds) {
         return problemRepository.findDetailByIdsInWithBookmark(memberId, problemIds);
     }
+
+    public List<ProblemWithBookmarkDetailQueryDto> findProblemsBySubjectId(Long memberId, List<Long> examIds, List<Long> subjectIds, int count) {
+        return subjectIds.stream()
+                .distinct()
+                .flatMap(subjectId -> {
+                    List<ProblemWithBookmarkDetailQueryDto> problems =
+                            findProblemsByExamIdsAndSubjectId(memberId, examIds, subjectId, count);
+                    Collections.shuffle(problems); // 문제 리스트를 랜덤으로 섞음
+                    return problems.stream().limit(count);
+                })
+                .toList();
+    }
+
+    public List<ProblemWithBookmarkDetailQueryDto> findProblemsByExamIdAndSubjectIds(Long memberId, Long examId, List<Long> subjectIds, int count) {
+        return subjectIds.stream()
+                .distinct()
+                .flatMap(subjectId -> {
+                    List<ProblemWithBookmarkDetailQueryDto> problems =
+                            problemRepository.findDetailByExamIdAndSubjectIdWithBookmark(memberId, examId, subjectId, MAX_PROBLEM_COUNT);
+                    Collections.shuffle(problems); // 문제 리스트를 랜덤으로 섞음
+                    return problems.stream().limit(count);
+                })
+                .toList();
+    }
+
+    private List<ProblemWithBookmarkDetailQueryDto> findProblemsByExamIdsAndSubjectId(Long memberId, List<Long> examIds, Long subjectId, int count) {
+        return examIds.stream()
+                .flatMap(examId -> problemRepository.findDetailByExamIdAndSubjectIdWithBookmark(memberId, examId, subjectId, MAX_PROBLEM_COUNT)
+                        .stream()
+                        .limit(count))
+                .collect(Collectors.toList());
+    }
+
 }

--- a/jabiseo-domain/src/main/java/com/jabiseo/problem/service/ProblemService.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/problem/service/ProblemService.java
@@ -11,7 +11,6 @@ import org.springframework.stereotype.Service;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -37,19 +36,11 @@ public class ProblemService {
         return problemRepository.findDetailByIdsInWithBookmark(memberId, problemIds);
     }
 
-    public List<ProblemWithBookmarkDetailQueryDto> findProblemsBySubjectId(Long memberId, List<Long> examIds, List<Long> subjectIds, int count) {
-        return subjectIds.stream()
-                .distinct()
-                .flatMap(subjectId -> {
-                    List<ProblemWithBookmarkDetailQueryDto> problems =
-                            findProblemsByExamIdsAndSubjectId(memberId, examIds, subjectId, count);
-                    Collections.shuffle(problems); // 문제 리스트를 랜덤으로 섞음
-                    return problems.stream().limit(count);
-                })
-                .toList();
-    }
-
     public List<ProblemWithBookmarkDetailQueryDto> findProblemsByExamIdAndSubjectIds(Long memberId, Long examId, List<Long> subjectIds, int count) {
+        // examId가 null일 경우 전체 시험을 대상으로 조회한다.
+        if (examId == null) {
+            return findProblemsBySubjectId(memberId, subjectIds, count);
+        }
         return subjectIds.stream()
                 .distinct()
                 .flatMap(subjectId -> {
@@ -61,12 +52,16 @@ public class ProblemService {
                 .toList();
     }
 
-    private List<ProblemWithBookmarkDetailQueryDto> findProblemsByExamIdsAndSubjectId(Long memberId, List<Long> examIds, Long subjectId, int count) {
-        return examIds.stream()
-                .flatMap(examId -> problemRepository.findDetailByExamIdAndSubjectIdWithBookmark(memberId, examId, subjectId, MAX_PROBLEM_COUNT)
-                        .stream()
-                        .limit(count))
-                .collect(Collectors.toList());
+    public List<ProblemWithBookmarkDetailQueryDto> findProblemsBySubjectId(Long memberId, List<Long> subjectIds, int count) {
+        return subjectIds.stream()
+                .distinct()
+                .flatMap(subjectId -> {
+                    List<ProblemWithBookmarkDetailQueryDto> problems =
+                            problemRepository.findDetailBySubjectIdWithBookmark(memberId, subjectId);
+                    Collections.shuffle(problems); // 문제 리스트를 랜덤으로 섞음
+                    return problems.stream().limit(count);
+                })
+                .toList();
     }
 
 }

--- a/jabiseo-domain/src/main/resources/domain.yml
+++ b/jabiseo-domain/src/main/resources/domain.yml
@@ -23,9 +23,6 @@ spring:
         show_sql: true
         format_sql: true
 
-logging.level:
-  org.hibernate.SQL: debug
-
 ---
 spring:
   config:

--- a/jabiseo-domain/src/test/java/com/jabiseo/problem/domain/BookmarkedProblemRepositoryTest.java
+++ b/jabiseo-domain/src/test/java/com/jabiseo/problem/domain/BookmarkedProblemRepositoryTest.java
@@ -25,12 +25,14 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static fixture.CertificateFixture.createCertificate;
 import static fixture.ExamFixture.createExam;
 import static fixture.MemberFixture.createMember;
 import static fixture.ProblemFixture.createProblem;
+import static fixture.ProblemInfoFixture.createProblemInfo;
 import static fixture.SubjectFixture.createSubject;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -53,6 +55,7 @@ class BookmarkedProblemRepositoryTest {
     private Certificate certificate;
     private List<Exam> exams;
     private List<Subject> subjects;
+    private List<ProblemInfo> problemInfos;
 
     @BeforeEach
     void setUp() {
@@ -73,6 +76,17 @@ class BookmarkedProblemRepositoryTest {
         examIds = exams.stream().map(Exam::getId).toList();
         subjectIds = subjects.stream().map(Subject::getId).toList();
         memberId = member.getId();
+
+        problemInfos = IntStream.range(0, examIds.size())
+                .boxed()
+                .flatMap(examIndex -> IntStream.range(0, subjectIds.size())
+                        .mapToObj(subjectIndex -> createProblemInfo(
+                                (long) examIndex * subjectIds.size() + subjectIndex + 1,  // ID를 고유하게 생성
+                                certificate.getId(),
+                                examIds.get(examIndex),
+                                subjectIds.get(subjectIndex))))
+                .collect(Collectors.toCollection(ArrayList::new));
+        problemInfos.forEach(entityManager::persist);
     }
 
     @Test
@@ -80,10 +94,10 @@ class BookmarkedProblemRepositoryTest {
     void givenExamAndSubjectConditions_whenFindingBookmarkedProblems_thenFindBookmarkedProblems() {
         //given
         List<Problem> requestProblems = List.of(
-                createProblem(certificate, exams.get(0), subjects.get(0)),
-                createProblem(certificate, exams.get(0), subjects.get(1)),
-                createProblem(certificate, exams.get(0), subjects.get(2)),
-                createProblem(certificate, exams.get(1), subjects.get(0))
+                createProblem(certificate, exams.get(0), subjects.get(0), getProblemInfo(examIds.get(0), subjectIds.get(0))),
+                createProblem(certificate, exams.get(0), subjects.get(1), getProblemInfo(examIds.get(0), subjectIds.get(1))),
+                createProblem(certificate, exams.get(0), subjects.get(2), getProblemInfo(examIds.get(0), subjectIds.get(2))),
+                createProblem(certificate, exams.get(1), subjects.get(0), getProblemInfo(examIds.get(1), subjectIds.get(0)))
         );
         List<Bookmark> bookmarks = requestProblems.stream()
                 .map(problem -> Bookmark.of(member, problem))
@@ -107,10 +121,10 @@ class BookmarkedProblemRepositoryTest {
     void givenSubjectConditions_whenFindingBookmarkedProblems_thenFindBookmarkedProblems() {
         //given
         List<Problem> requestProblems = List.of(
-                createProblem(certificate, exams.get(0), subjects.get(0)),
-                createProblem(certificate, exams.get(0), subjects.get(1)),
-                createProblem(certificate, exams.get(0), subjects.get(2)),
-                createProblem(certificate, exams.get(1), subjects.get(0))
+                createProblem(certificate, exams.get(0), subjects.get(0), getProblemInfo(examIds.get(0), subjectIds.get(0))),
+                createProblem(certificate, exams.get(0), subjects.get(1), getProblemInfo(examIds.get(0), subjectIds.get(1))),
+                createProblem(certificate, exams.get(0), subjects.get(2), getProblemInfo(examIds.get(0), subjectIds.get(2))),
+                createProblem(certificate, exams.get(1), subjects.get(0), getProblemInfo(examIds.get(1), subjectIds.get(0)))
         );
         List<Bookmark> bookmarks = requestProblems.stream()
                 .map(problem -> Bookmark.of(member, problem))
@@ -135,7 +149,7 @@ class BookmarkedProblemRepositoryTest {
     void givenExamAndSubjectConditionsWithMultiplePage_whenFindingBookmarkedProblems_thenFindBookmarkedProblems(int page, int pageSize) {
         //given
         List<Problem> requestProblems = IntStream.range(0, 15)
-                .mapToObj(id -> createProblem(certificate, exams.get(0), subjects.get(0)))
+                .mapToObj(id -> createProblem(certificate, exams.get(0), subjects.get(0), getProblemInfo(examIds.get(0), subjectIds.get(0))))
                 .toList();
         List<Bookmark> bookmarks = requestProblems.stream()
                 .map(problem -> Bookmark.of(member, problem))
@@ -152,6 +166,13 @@ class BookmarkedProblemRepositoryTest {
         //then
         assertThat(dtos).hasSize(pageSize);
         dtos.forEach(dto -> assertThat(dto.isBookmark()).isTrue());
+    }
+
+    private ProblemInfo getProblemInfo(Long examId, Long subjectId) {
+        return problemInfos.stream()
+                .filter(problemInfo -> problemInfo.getExamId().equals(examId) && problemInfo.getSubjectId().equals(subjectId))
+                .findFirst()
+                .orElseThrow();
     }
 
 }

--- a/jabiseo-domain/src/test/java/com/jabiseo/problem/domain/ProblemRepositoryTest.java
+++ b/jabiseo-domain/src/test/java/com/jabiseo/problem/domain/ProblemRepositoryTest.java
@@ -90,7 +90,7 @@ class ProblemRepositoryTest {
     @DisplayName("로그인한 유저가 시험, 과목 조건에 따라 문제 세트를 조회하는 쿼리가 정상적으로 동작한다.")
     void givenLoginMemberWithExamAndSubjectConditions_whenFindingProblems_thenFindProblems() {
         //when
-        List<ProblemWithBookmarkDetailQueryDto> dtos = problemRepository.findDetailRandomByExamIdAndSubjectIdWithBookmark(
+        List<ProblemWithBookmarkDetailQueryDto> dtos = problemRepository.findDetailByExamIdAndSubjectIdWithBookmark(
                 memberId, examIds.get(0), subjectIds.get(0), count
         );
 
@@ -104,7 +104,7 @@ class ProblemRepositoryTest {
     @DisplayName("로그인한 유저가 시험을 제외한 과목 조건에 따라 문제 세트를 조회하는 쿼리가 정상적으로 동작한다.")
     void givenLoginMemberWithSubjectConditions_whenFindingProblems_thenFindProblems() {
         //when
-        List<ProblemWithBookmarkDetailQueryDto> dtos = problemRepository.findDetailRandomByExamIdAndSubjectIdWithBookmark(
+        List<ProblemWithBookmarkDetailQueryDto> dtos = problemRepository.findDetailByExamIdAndSubjectIdWithBookmark(
                 memberId, null, subjectIds.get(0), count
         );
 
@@ -118,7 +118,7 @@ class ProblemRepositoryTest {
     @DisplayName("비로그인 유저가 시험, 과목 조건에 따라 문제 세트를 조회하는 쿼리가 정상적으로 동작한다.")
     void givenNonLoginMemberWithExamAndSubjectConditions_whenFindingProblems_thenFindProblems() {
         //when
-        List<ProblemWithBookmarkDetailQueryDto> dtos = problemRepository.findDetailRandomByExamIdAndSubjectIdWithBookmark(
+        List<ProblemWithBookmarkDetailQueryDto> dtos = problemRepository.findDetailByExamIdAndSubjectIdWithBookmark(
                 null, examIds.get(0), subjectIds.get(0), count
         );
 
@@ -132,7 +132,7 @@ class ProblemRepositoryTest {
     @DisplayName("비로그인 유저가 시험을 제외한 과목 조건에 따라 문제 세트를 조회하는 쿼리가 정상적으로 동작한다.")
     void givenNonLoginMemberWithSubjectConditions_whenFindingProblems_thenFindProblems() {
         //when
-        List<ProblemWithBookmarkDetailQueryDto> dtos = problemRepository.findDetailRandomByExamIdAndSubjectIdWithBookmark(
+        List<ProblemWithBookmarkDetailQueryDto> dtos = problemRepository.findDetailByExamIdAndSubjectIdWithBookmark(
                 null, null, subjectIds.get(0), count
         );
 

--- a/jabiseo-domain/src/test/java/com/jabiseo/problem/domain/ProblemServiceTest.java
+++ b/jabiseo-domain/src/test/java/com/jabiseo/problem/domain/ProblemServiceTest.java
@@ -1,0 +1,107 @@
+package com.jabiseo.problem.domain;
+
+import com.jabiseo.certificate.domain.Certificate;
+import com.jabiseo.certificate.domain.Exam;
+import com.jabiseo.certificate.domain.Subject;
+import com.jabiseo.problem.dto.ProblemWithBookmarkDetailQueryDto;
+import com.jabiseo.problem.service.ProblemService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+
+import static fixture.CertificateFixture.createCertificate;
+import static fixture.ExamFixture.createExam;
+import static fixture.ProblemFixture.createProblem;
+import static fixture.ProblemWithBookmarkDetailQueryDtoFixture.createProblemWithBookmarkDetailQueryDto;
+import static fixture.SubjectFixture.createSubject;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@DisplayName("문제 서비스 테스트")
+@ExtendWith(MockitoExtension.class)
+public class ProblemServiceTest {
+
+    @InjectMocks
+    ProblemService sut;
+
+    @Mock
+    ProblemRepository problemRepository;
+
+    Long memberId;
+    Long certificateId;
+    List<Long> examIds;
+    List<Long> subjectIds;
+    List<Exam> exams;
+    List<Subject> subjects;
+    List<Problem> problems1;
+    List<Problem> problems2;
+    List<Problem> problems3;
+    List<Problem> problems4;
+
+    @BeforeEach
+    void setUp() {
+        memberId = 1L;
+        certificateId = 1L;
+        Certificate certificate = createCertificate(certificateId);
+        examIds = List.of(1L, 2L);
+        subjectIds = List.of(3L, 4L);
+        exams = examIds.stream().map(e -> createExam(e, certificate)).toList();
+        subjects = subjectIds.stream().map(s -> createSubject(s, certificate)).toList();
+        problems1 = LongStream.range(1, 21).mapToObj(i -> createProblem(i, certificate, exams.get(0), subjects.get(0))).toList();
+        problems2 = LongStream.range(21, 41).mapToObj(i -> createProblem(i, certificate, exams.get(0), subjects.get(1))).toList();
+        problems3 = LongStream.range(41, 61).mapToObj(i -> createProblem(i, certificate, exams.get(1), subjects.get(0))).toList();
+        problems4 = LongStream.range(61, 81).mapToObj(i -> createProblem(i, certificate, exams.get(1), subjects.get(1))).toList();
+    }
+
+    @Test
+    @DisplayName("문제 조회 시 중복된 과목 ID가 요청되는 경우 중복 제거 후 결과를 반환한다.")
+    void givenDuplicateSubjectIds_whenGetProblemsBySubjectIds_thenRemoveDuplicateSubjectIds() {
+        //given
+        Long examId = examIds.get(0);
+        List<Long> subjectIds = List.of(this.subjectIds.get(0), this.subjectIds.get(0));
+        int count = 10;
+
+        given(problemRepository.findDetailByExamIdAndSubjectIdWithBookmark(memberId, examIds.get(0), subjectIds.get(0), 20))
+                .willReturn(problems1.stream().map(p -> createProblemWithBookmarkDetailQueryDto(p, true)).collect(Collectors.toList()));
+
+        //when
+        List<ProblemWithBookmarkDetailQueryDto> result = sut.findProblemsByExamIdAndSubjectIds(memberId, examId, subjectIds, count);
+
+        //then
+        result.forEach(dto -> assertThat(dto.subjectId()).isEqualTo(this.subjectIds.get(0)));
+        result.forEach(dto -> assertThat(dto.examId()).isEqualTo(examId));
+    }
+
+    @Test
+    @DisplayName("시험 조건이 없는 문제 조회 시 과목 마다 count 개수만큼 순서대로 문제를 반환한다.")
+    void givenNoExamId_whenGetProblemsBySubjectIds_thenReturnProblemsByCount() {
+        //given
+        int count = 5;
+
+        given(problemRepository.findDetailByExamIdAndSubjectIdWithBookmark(memberId, examIds.get(0), subjectIds.get(0), 20))
+                .willReturn(problems1.stream().map(p -> createProblemWithBookmarkDetailQueryDto(p, true)).collect(Collectors.toList()));
+        given(problemRepository.findDetailByExamIdAndSubjectIdWithBookmark(memberId, examIds.get(0), subjectIds.get(1), 20))
+                .willReturn(problems2.stream().map(p -> createProblemWithBookmarkDetailQueryDto(p, true)).collect(Collectors.toList()));
+        given(problemRepository.findDetailByExamIdAndSubjectIdWithBookmark(memberId, examIds.get(1), subjectIds.get(0), 20))
+                .willReturn(problems3.stream().map(p -> createProblemWithBookmarkDetailQueryDto(p, true)).collect(Collectors.toList()));
+        given(problemRepository.findDetailByExamIdAndSubjectIdWithBookmark(memberId, examIds.get(1), subjectIds.get(1), 20))
+                .willReturn(problems4.stream().map(p -> createProblemWithBookmarkDetailQueryDto(p, true)).collect(Collectors.toList()));
+
+        //when
+        List<ProblemWithBookmarkDetailQueryDto> result = sut.findProblemsBySubjectId(memberId, examIds, subjectIds, count);
+
+        //then
+        result.subList(0, count)
+                .forEach(dto -> assertThat(dto.subjectId()).isEqualTo(subjectIds.get(0)));
+        result.subList(count, count * 2)
+                .forEach(dto -> assertThat(dto.subjectId()).isEqualTo(subjectIds.get(1)));
+    }
+}

--- a/jabiseo-domain/src/test/java/com/jabiseo/problem/domain/ProblemServiceTest.java
+++ b/jabiseo-domain/src/test/java/com/jabiseo/problem/domain/ProblemServiceTest.java
@@ -86,17 +86,13 @@ public class ProblemServiceTest {
         //given
         int count = 5;
 
-        given(problemRepository.findDetailByExamIdAndSubjectIdWithBookmark(memberId, examIds.get(0), subjectIds.get(0), 20))
+        given(problemRepository.findDetailBySubjectIdWithBookmark(memberId, subjectIds.get(0)))
                 .willReturn(problems1.stream().map(p -> createProblemWithBookmarkDetailQueryDto(p, true)).collect(Collectors.toList()));
-        given(problemRepository.findDetailByExamIdAndSubjectIdWithBookmark(memberId, examIds.get(0), subjectIds.get(1), 20))
+        given(problemRepository.findDetailBySubjectIdWithBookmark(memberId, subjectIds.get(1)))
                 .willReturn(problems2.stream().map(p -> createProblemWithBookmarkDetailQueryDto(p, true)).collect(Collectors.toList()));
-        given(problemRepository.findDetailByExamIdAndSubjectIdWithBookmark(memberId, examIds.get(1), subjectIds.get(0), 20))
-                .willReturn(problems3.stream().map(p -> createProblemWithBookmarkDetailQueryDto(p, true)).collect(Collectors.toList()));
-        given(problemRepository.findDetailByExamIdAndSubjectIdWithBookmark(memberId, examIds.get(1), subjectIds.get(1), 20))
-                .willReturn(problems4.stream().map(p -> createProblemWithBookmarkDetailQueryDto(p, true)).collect(Collectors.toList()));
 
         //when
-        List<ProblemWithBookmarkDetailQueryDto> result = sut.findProblemsBySubjectId(memberId, examIds, subjectIds, count);
+        List<ProblemWithBookmarkDetailQueryDto> result = sut.findProblemsBySubjectId(memberId, subjectIds, count);
 
         //then
         result.subList(0, count)

--- a/jabiseo-domain/src/testFixtures/java/fixture/ProblemFixture.java
+++ b/jabiseo-domain/src/testFixtures/java/fixture/ProblemFixture.java
@@ -4,9 +4,11 @@ import com.jabiseo.certificate.domain.Certificate;
 import com.jabiseo.certificate.domain.Exam;
 import com.jabiseo.certificate.domain.Subject;
 import com.jabiseo.problem.domain.Problem;
+import com.jabiseo.problem.domain.ProblemInfo;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import static fixture.CertificateFixture.createCertificate;
+import static fixture.ProblemInfoFixture.createProblemInfo;
 import static fixture.SubjectFixture.createSubject;
 
 public class ProblemFixture {
@@ -22,7 +24,8 @@ public class ProblemFixture {
                 1,
                 certificate,
                 exam,
-                subject
+                subject,
+                createProblemInfo(certificate.getId(), exam.getId(), subject.getId())
         );
         ReflectionTestUtils.setField(problem, "id", id);
         return problem;
@@ -49,7 +52,8 @@ public class ProblemFixture {
                 1,
                 certificate,
                 ExamFixture.createExam(5432L, certificate),
-                createSubject(9876L, certificate)
+                createSubject(9876L, certificate),
+                createProblemInfo(certificate.getId(), 5432L, 9876L)
         );
         ReflectionTestUtils.setField(problem, "id", id);
         return problem;
@@ -67,7 +71,25 @@ public class ProblemFixture {
                 1,
                 certificate,
                 exam,
-                subject
+                subject,
+                createProblemInfo(certificate.getId(), exam.getId(), subject.getId())
+        );
+    }
+
+    public static Problem createProblem(Certificate certificate, Exam exam, Subject subject, ProblemInfo problemInfo) {
+        return Problem.of(
+                "problem description",
+                "choice1",
+                "choice2",
+                "choice3",
+                "choice4",
+                1,
+                "problem theory",
+                1,
+                certificate,
+                exam,
+                subject,
+                problemInfo
         );
     }
 }

--- a/jabiseo-domain/src/testFixtures/java/fixture/ProblemInfoFixture.java
+++ b/jabiseo-domain/src/testFixtures/java/fixture/ProblemInfoFixture.java
@@ -1,0 +1,17 @@
+package fixture;
+
+import com.jabiseo.problem.domain.ProblemInfo;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class ProblemInfoFixture {
+
+    public static ProblemInfo createProblemInfo(Long certificateId, Long examId, Long subjectId) {
+        return ProblemInfo.of(certificateId, "certificate name", examId, "exam description", 2021, 1, subjectId, "subject name", 1);
+    }
+
+    public static ProblemInfo createProblemInfo(Long id, Long certificateId, Long examId, Long subjectId) {
+        ProblemInfo problemInfo = ProblemInfo.of(certificateId, "certificate name", examId, "exam description", 2021, 1, subjectId, "subject name", 1);
+        ReflectionTestUtils.setField(problemInfo, "id", id);
+        return problemInfo;
+    }
+}


### PR DESCRIPTION
## PR 변경된 내용
### 역정규화 테이블 ProblemInfo 생성
- 기존 쿼리는 problem을 조회할 때 exam, subject를 모두 조인하는 성능상 문제 발생
- 따라서 certificate, exam, subject를 Cartesian Product 한 테이블인 ProblemInfo Entity를 새로 생성
- 여러 문제가 발생할 수도 있지만, 다음과 같은 이유에서 타당하다고 보았음
  - 기존 certificate, exam, subject 테이블과 정합성의 문제: Problem, Certificate, Exam, Subject, ProblemInfo 모두 서비스 상에서는 조회만 가능한 데이터이고 개발자가 직접 수정하는 데이터이므로 어느 정도 해결 가능하다고 보았음. 또한 외부에서 정합성이 맞는지 체크하는 코드를 가지고 있어, 생성/수정/삭제 시마다 체크할 예정.
  - 데이터 개수가 너무 많을 수 있다는 문제: 현재 존재하는 자격증의 모든 정보를 넣더라도 해당 테이블의 데이터는 최대 100 * 6 * 10 = 6000 개를 넘지 않을 것으로 보임.

### Bookmark 여부를 서브쿼리로 가져오던 것에서 join으로 가져오도록 변경
- 서브쿼리는 효율이 굉장히 좋지 않은데, 기존에 서브 쿼리로 확인하던 문제 발견
- 따라서 left join으로 변경함. 아래와 같이 64.63% 성능 개선이 됨
![image](https://github.com/user-attachments/assets/92f2599e-e101-4796-9ea2-acf36023dd6a)

### 랜덤 쿼리 개선
- 기존에 각 과목마다 최대 20문제를 랜덤으로 가져오는 부분에서 RAND() 함수를 통해 MySQL에 쿼리를 날림
- 20문제를 모두 가져와서 랜덤으로 섞은 후 원하는 개수를 반환하는 것으로 변경

- 위 사항들에 따른 테스트 코드 변경
  - Problem을 만들 때 ProblemInfo 와 매핑해야 하는 부분에서 수정이 많이 발생

### FindProblemsUseCase 구조 변경
- 멀티모듈에 알맞게 UseCase에서 Repository를 참조하면서 비즈니스 로직을 담당했던 부분을, Service를 참조하면서 책임을 옮김

### QueryDSL 코드 리팩토링
- 기존에 쓰던 쿼리들에서 select, from 절은 모두 중복되게 쓰이므로 해당 부분을 메소드로 따로 뺴면서 리팩토링

## 추가 내용
- API 명세에 맞게 응답 DTO의 변수명 변경

## 참조
Closes #76 
