### PR TITLE
Feat(Problem): 검색 기능 구현

### DIFF
--- a/jabiseo-api/src/main/java/com/jabiseo/problem/application/usecase/SearchProblemUseCase.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/problem/application/usecase/SearchProblemUseCase.java
@@ -2,6 +2,7 @@ package com.jabiseo.problem.application.usecase;
 
 import com.jabiseo.problem.dto.SearchProblemResponse;
 import com.jabiseo.problem.service.ProblemService;
+import jakarta.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,7 +16,8 @@ public class SearchProblemUseCase {
 
     private final ProblemService problemService;
 
-    public List<SearchProblemResponse> execute(Long memberId, Long certificateId, String query, Double lastScore, Long lastId) {
+    public List<SearchProblemResponse> execute(Long memberId, Long certificateId, String query,
+                                               @Nullable Double lastScore, @Nullable Long lastId) {
         return problemService.searchProblem(memberId, certificateId, query, lastScore, lastId).stream()
                 .map(SearchProblemResponse::from)
                 .toList();

--- a/jabiseo-api/src/main/java/com/jabiseo/problem/application/usecase/SearchProblemUseCase.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/problem/application/usecase/SearchProblemUseCase.java
@@ -1,0 +1,23 @@
+package com.jabiseo.problem.application.usecase;
+
+import com.jabiseo.problem.dto.SearchProblemResponse;
+import com.jabiseo.problem.service.ProblemService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class SearchProblemUseCase {
+
+    private final ProblemService problemService;
+
+    public List<SearchProblemResponse> execute(Long memberId, Long certificateId, String query, Double lastScore, Long lastId) {
+        return problemService.searchProblem(memberId, certificateId, query, lastScore, lastId).stream()
+                .map(SearchProblemResponse::from)
+                .toList();
+    }
+}

--- a/jabiseo-api/src/main/java/com/jabiseo/problem/controller/ProblemController.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/problem/controller/ProblemController.java
@@ -36,6 +36,8 @@ public class ProblemController {
 
     private final FindRecommendedProblemsUseCase findRecommendedProblemsUseCase;
 
+    private final SearchProblemUseCase searchProblemUseCase;
+
     @GetMapping("/set")
     public ResponseEntity<FindProblemsResponse> findProblems(
             @AuthenticatedMember AuthMember member,
@@ -119,6 +121,18 @@ public class ProblemController {
             @AuthenticatedMember AuthMember member
     ) {
         FindProblemsResponse result = findRecommendedProblemsUseCase.execute(member.getMemberId());
+        return ResponseEntity.ok(result);
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<List<SearchProblemResponse>> searchProblem(
+            @AuthenticatedMember AuthMember member,
+            @RequestParam(name = "certificate-id") Long certificateId,
+            @RequestParam String query,
+            @RequestParam(required = false, name = "last-score") Double lastScore,
+            @RequestParam(required = false, name = "last-id") Long lastId
+    ) {
+        List<SearchProblemResponse> result = searchProblemUseCase.execute(member.getMemberId(), certificateId, query, lastScore, lastId);
         return ResponseEntity.ok(result);
     }
 

--- a/jabiseo-api/src/main/java/com/jabiseo/problem/dto/SearchProblemResponse.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/problem/dto/SearchProblemResponse.java
@@ -1,0 +1,24 @@
+package com.jabiseo.problem.dto;
+
+import com.jabiseo.certificate.dto.ExamResponse;
+import com.jabiseo.certificate.dto.SubjectResponse;
+
+public record SearchProblemResponse(
+        Long problemId,
+        Double score,
+        ExamResponse examInfo,
+        SubjectResponse subjectInfo,
+        boolean isBookmarked,
+        String description
+) {
+    public static SearchProblemResponse from(ProblemWithBookmarkSummaryScoreQueryDto dto) {
+        return new SearchProblemResponse(
+                dto.problemId(),
+                dto.score(),
+                ExamResponse.of(dto.examId(), dto.examDescription()),
+                SubjectResponse.of(dto.subjectId(), dto.subjectSequence(), dto.subjectName()),
+                dto.isBookmark(),
+                dto.description()
+        );
+    }
+}

--- a/jabiseo-domain/src/main/java/com/jabiseo/problem/dto/ProblemSearchDto.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/problem/dto/ProblemSearchDto.java
@@ -1,0 +1,10 @@
+package com.jabiseo.problem.dto;
+
+public record ProblemSearchDto(
+        Long problemId,
+        Double score
+) {
+    public static ProblemSearchDto of(Long problemId, Double score) {
+        return new ProblemSearchDto(problemId, score);
+    }
+}

--- a/jabiseo-domain/src/main/java/com/jabiseo/problem/dto/ProblemWithBookmarkSummaryScoreQueryDto.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/problem/dto/ProblemWithBookmarkSummaryScoreQueryDto.java
@@ -1,0 +1,29 @@
+package com.jabiseo.problem.dto;
+
+public record ProblemWithBookmarkSummaryScoreQueryDto(
+        Long problemId,
+        Double score,
+        String description,
+        boolean isBookmark,
+
+        Long examId,
+        String examDescription,
+
+        Long subjectId,
+        String subjectName,
+        int subjectSequence
+) {
+    public static ProblemWithBookmarkSummaryScoreQueryDto of(ProblemWithBookmarkSummaryQueryDto dto, Double score) {
+        return new ProblemWithBookmarkSummaryScoreQueryDto(
+                dto.problemId(),
+                score,
+                dto.description(),
+                dto.isBookmark(),
+                dto.examId(),
+                dto.examDescription(),
+                dto.subjectId(),
+                dto.subjectName(),
+                dto.subjectSequence()
+        );
+    }
+}

--- a/jabiseo-domain/src/main/java/com/jabiseo/problem/service/ProblemSearchProvider.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/problem/service/ProblemSearchProvider.java
@@ -1,0 +1,9 @@
+package com.jabiseo.problem.service;
+
+import com.jabiseo.problem.dto.ProblemSearchDto;
+
+import java.util.List;
+
+public interface ProblemSearchProvider {
+    List<ProblemSearchDto> searchProblem(String query, Double lastScore, Long lastId, Long certificateId, int searchProblemCount);
+}

--- a/jabiseo-infrastructure/src/main/java/com/jabiseo/opensearch/OpenSearchProblemSearchProvider.java
+++ b/jabiseo-infrastructure/src/main/java/com/jabiseo/opensearch/OpenSearchProblemSearchProvider.java
@@ -1,0 +1,39 @@
+package com.jabiseo.opensearch;
+
+import com.jabiseo.opensearch.helper.OpenSearchHelper;
+import com.jabiseo.opensearch.helper.OpenSearchResultDto;
+import com.jabiseo.problem.dto.ProblemSearchDto;
+import com.jabiseo.problem.service.ProblemSearchProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class OpenSearchProblemSearchProvider implements ProblemSearchProvider {
+
+    private final OpenSearchHelper openSearchHelper;
+
+    // 검색할 필드 목록, OpenSearch의 결과에서 해당 컬럼명으로 값을 가져와야 함
+    private static final List<String> SEARCH_FIELDS = List.of("description", "choice1", "choice2", "choice3", "choice4");
+
+    @Override
+    public List<ProblemSearchDto> searchProblem(String query, Double lastScore, Long lastId, Long certificateId, int searchProblemCount) {
+        // 자격증에 해당하는 인덱스 이름
+        CertificateIndexInfo certificateIndexInfo = CertificateIndexInfo.findByCertificateId(certificateId);
+        String indexName = certificateIndexInfo.getProblemIndexName();
+        List<OpenSearchResultDto> dtos = fetchFromOpenSearch(query, lastScore, lastId, indexName, searchProblemCount);
+        return dtos.stream()
+                .map(dto -> ProblemSearchDto.of(Long.parseLong(dto.id()), dto.score()))
+                .toList();
+    }
+
+    private List<OpenSearchResultDto> fetchFromOpenSearch(String query, Double lastScore, Long lastId, String indexName, int searchProblemCount) {
+        if (lastScore == null || lastId == null) {
+            return openSearchHelper.searchProblemInMultiField(query, indexName, SEARCH_FIELDS, searchProblemCount);
+        }
+        return openSearchHelper.searchProblemInMultiFieldAfter(query, indexName, SEARCH_FIELDS, lastScore.floatValue(), lastId, searchProblemCount);
+    }
+
+}

--- a/jabiseo-infrastructure/src/main/java/com/jabiseo/opensearch/helper/OpenSearchResultDto.java
+++ b/jabiseo-infrastructure/src/main/java/com/jabiseo/opensearch/helper/OpenSearchResultDto.java
@@ -4,10 +4,10 @@ import jakarta.json.JsonValue;
 
 public record OpenSearchResultDto(
         String id,
-        double score,
+        Double score,
         JsonValue source
 ) {
-    public static OpenSearchResultDto of(String id, double score, JsonValue source) {
+    public static OpenSearchResultDto of(String id, Double score, JsonValue source) {
         return new OpenSearchResultDto(id, score, source);
     }
 }

--- a/jabiseo-infrastructure/src/test/java/com/jabiseo/opensearch/OpenSearchProblemSearchProviderTest.java
+++ b/jabiseo-infrastructure/src/test/java/com/jabiseo/opensearch/OpenSearchProblemSearchProviderTest.java
@@ -1,0 +1,62 @@
+package com.jabiseo.opensearch;
+
+import com.jabiseo.opensearch.helper.OpenSearchHelper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Objects;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+
+@DisplayName("OpenSearchProblemSearchProvider 테스트")
+@ExtendWith(MockitoExtension.class)
+class OpenSearchProblemSearchProviderTest {
+
+    @InjectMocks
+    OpenSearchProblemSearchProvider sut;
+
+    @Mock
+    OpenSearchHelper openSearchHelper;
+
+    @ParameterizedTest
+    @DisplayName("문제 검색 시 last score나 last id가 없으면 openSearchHelper.searchProblemInMultiField 메서드를 호출한다.")
+    @CsvSource({"null, null", "null, 1", "1.0, null"})
+    void givenNoLastScoreAndLastId_whenSearchProblem_thenCallOpenSearchHelperSearchProblemInMultiField(String lastScore, String lastId) {
+        // given
+        String query = "query";
+        String indexName = "jeongbocheorigisa";
+        int searchProblemCount = 10;
+
+        // when
+        sut.searchProblem(query, Objects.equals(lastScore, "null") ? null : 1.0, lastId.equals("null") ? null : 1L, 1L, searchProblemCount);
+
+        // then
+        verify(openSearchHelper).searchProblemInMultiField(eq(query), eq(indexName), any(), eq(searchProblemCount));
+    }
+
+    @Test
+    @DisplayName("문제 검색 시 last score와 last id가 있으면 openSearchHelper.searchProblemInMultiFieldAfter 메서드를 호출한다.")
+    void givenLastScoreAndLastId_whenSearchProblem_thenCallOpenSearchHelperSearchProblemInMultiFieldAfter() {
+        // given
+        String query = "query";
+        Double lastScore = 1.0;
+        Long lastId = 1L;
+        String indexName = "jeongbocheorigisa";
+        int searchProblemCount = 10;
+
+        // when
+        sut.searchProblem(query, lastScore, lastId, 1L, searchProblemCount);
+
+        // then
+        verify(openSearchHelper).searchProblemInMultiFieldAfter(eq(query), eq(indexName), any(), eq(lastScore.floatValue()), eq(lastId), eq(searchProblemCount));
+    }
+
+}


### PR DESCRIPTION
## PR 변경된 내용
### 문제 검색 구현
- OpenSearch의 검색 API를 활용해 적용
- 커서 기반 페이지네이션을 위해 score와 id 값을 반환, 2번째 요청 부터는 해당 값을 last-score, last-id로 모두 주어야 함
- 검색 결과는 10개씩 주고, 검색 결과가 없으면 프론트엔드에서 요청을 그만한다.
- ProblemService의 구현 중, OpenSearch의 결과와 MySQL의 결과를 문제의 id에 맞춰 같은 DTO 클래스에 실어야 했다. 이 작업을 O(N)에 끝내기 위해 MySQL의 결과를 HashMap에 넣어두고, DTO 클래스를 만들 때 사용했다.
  - MySQL의 결과(예를 들어 리스트A)를 오픈서치에서 가져온 문제 리스트(리스트B)의 순서대로 정렬해야 한다. HashMap을 사용하지 않으면 리스트A의 원소마다 리스트B를 순회하기 때문에 O(N^2)이 걸린다.
- 관련 테스트 구현함

## 참조
Closes #83 
