### PR TITLE
Feat(FCM): FCM 리프레시 로직 및 다중 로그인 구현

### DIFF
--- a/jabiseo-api/src/main/java/com/jabiseo/api/auth/application/DevLoginHelper.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/api/auth/application/DevLoginHelper.java
@@ -2,32 +2,30 @@ package com.jabiseo.api.auth.application;
 
 
 import com.jabiseo.api.auth.dto.LoginResponse;
-import com.jabiseo.api.config.deviceinfo.DeviceInfo;
 import com.jabiseo.domain.auth.domain.Auth;
 import com.jabiseo.domain.auth.domain.AuthService;
 import com.jabiseo.domain.member.domain.Member;
+import com.jabiseo.domain.member.service.DeviceTokenService;
 import com.jabiseo.domain.member.service.MemberService;
-import com.jabiseo.infra.cache.RedisCacheRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class DevLoginHelper {
 
     private final JwtHandler jwtHandler;
     private final MemberService memberService;
     private final AuthService authService;
-    private final RedisCacheRepository redisCacheRepository;
+    private final DeviceTokenService deviceTokenService;
 
-    public LoginResponse login(Long memberId, String deviceId) {
+    public LoginResponse login(Long memberId, String deviceId, String token) {
         Member member = memberService.getById(memberId);
 
         String accessToken = jwtHandler.createAccessToken(member);
         String refreshToken = jwtHandler.createRefreshToken();
         authService.login(Auth.create(deviceId, memberId, refreshToken));
+        deviceTokenService.loginToken(member, token, deviceId);
         return new LoginResponse(accessToken, refreshToken);
     }
 

--- a/jabiseo-api/src/main/java/com/jabiseo/api/auth/application/DevLoginHelper.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/api/auth/application/DevLoginHelper.java
@@ -2,6 +2,9 @@ package com.jabiseo.api.auth.application;
 
 
 import com.jabiseo.api.auth.dto.LoginResponse;
+import com.jabiseo.api.config.deviceinfo.DeviceInfo;
+import com.jabiseo.domain.auth.domain.Auth;
+import com.jabiseo.domain.auth.domain.AuthService;
 import com.jabiseo.domain.member.domain.Member;
 import com.jabiseo.domain.member.service.MemberService;
 import com.jabiseo.infra.cache.RedisCacheRepository;
@@ -16,14 +19,15 @@ public class DevLoginHelper {
 
     private final JwtHandler jwtHandler;
     private final MemberService memberService;
+    private final AuthService authService;
     private final RedisCacheRepository redisCacheRepository;
 
-    public LoginResponse login(Long memberId) {
+    public LoginResponse login(Long memberId, String deviceId) {
         Member member = memberService.getById(memberId);
 
         String accessToken = jwtHandler.createAccessToken(member);
         String refreshToken = jwtHandler.createRefreshToken();
-        redisCacheRepository.saveToken(member.getId(), refreshToken);
+        authService.login(Auth.create(deviceId, memberId, refreshToken));
         return new LoginResponse(accessToken, refreshToken);
     }
 

--- a/jabiseo-api/src/main/java/com/jabiseo/api/auth/application/usecase/LoginUseCase.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/api/auth/application/usecase/LoginUseCase.java
@@ -9,6 +9,7 @@ import com.jabiseo.domain.auth.domain.AuthService;
 import com.jabiseo.domain.member.domain.Member;
 import com.jabiseo.domain.member.domain.OauthMemberInfo;
 import com.jabiseo.domain.member.domain.OauthServer;
+import com.jabiseo.domain.member.service.DeviceTokenService;
 import com.jabiseo.domain.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -23,6 +24,7 @@ public class LoginUseCase {
     private final JwtHandler jwtHandler;
     private final MemberService memberService;
     private final AuthService authService;
+    private final DeviceTokenService deviceTokenService;
 
     public LoginResponse execute(LoginRequest loginRequest, String deviceId) {
         OauthMemberInfo oauthMemberInfo = tokenValidatorManager.validate(loginRequest.idToken(), OauthServer.valueOf(loginRequest.oauthServer()));
@@ -32,6 +34,7 @@ public class LoginUseCase {
         String accessToken = jwtHandler.createAccessToken(member);
         String refreshToken = jwtHandler.createRefreshToken();
         authService.login(Auth.create(deviceId, member.getId(), refreshToken));
+        deviceTokenService.loginToken(member, loginRequest.fcmToken(), deviceId);
 
         return new LoginResponse(accessToken, refreshToken);
     }

--- a/jabiseo-api/src/main/java/com/jabiseo/api/auth/application/usecase/LoginUseCase.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/api/auth/application/usecase/LoginUseCase.java
@@ -4,11 +4,12 @@ import com.jabiseo.api.auth.application.JwtHandler;
 import com.jabiseo.api.auth.application.oidc.TokenValidatorManager;
 import com.jabiseo.api.auth.dto.LoginRequest;
 import com.jabiseo.api.auth.dto.LoginResponse;
+import com.jabiseo.domain.auth.domain.Auth;
+import com.jabiseo.domain.auth.domain.AuthService;
 import com.jabiseo.domain.member.domain.Member;
 import com.jabiseo.domain.member.domain.OauthMemberInfo;
 import com.jabiseo.domain.member.domain.OauthServer;
 import com.jabiseo.domain.member.service.MemberService;
-import com.jabiseo.infra.cache.RedisCacheRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,16 +22,16 @@ public class LoginUseCase {
     private final TokenValidatorManager tokenValidatorManager;
     private final JwtHandler jwtHandler;
     private final MemberService memberService;
-    private final RedisCacheRepository cacheRepository;
+    private final AuthService authService;
 
-    public LoginResponse execute(LoginRequest loginRequest) {
+    public LoginResponse execute(LoginRequest loginRequest, String deviceId) {
         OauthMemberInfo oauthMemberInfo = tokenValidatorManager.validate(loginRequest.idToken(), OauthServer.valueOf(loginRequest.oauthServer()));
 
         Member member = memberService.getByOauthIdAndOauthServerOrCreateMember(oauthMemberInfo);
 
         String accessToken = jwtHandler.createAccessToken(member);
         String refreshToken = jwtHandler.createRefreshToken();
-        cacheRepository.saveToken(member.getId(), refreshToken);
+        authService.login(Auth.create(deviceId, member.getId(), refreshToken));
 
         return new LoginResponse(accessToken, refreshToken);
     }

--- a/jabiseo-api/src/main/java/com/jabiseo/api/auth/application/usecase/LogoutUseCase.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/api/auth/application/usecase/LogoutUseCase.java
@@ -2,7 +2,9 @@ package com.jabiseo.api.auth.application.usecase;
 
 import com.jabiseo.domain.auth.domain.Auth;
 import com.jabiseo.domain.auth.domain.AuthService;
-import com.jabiseo.infra.cache.RedisCacheRepository;
+import com.jabiseo.domain.member.domain.Member;
+import com.jabiseo.domain.member.service.DeviceTokenService;
+import com.jabiseo.domain.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,9 +15,14 @@ import org.springframework.transaction.annotation.Transactional;
 public class LogoutUseCase {
 
     private final AuthService authService;
+    private final DeviceTokenService deviceTokenService;
+    private final MemberService memberService;
 
     public void execute(Long memberId, String deviceId) {
         authService.logout(Auth.create(deviceId, memberId, null));
+
+        Member member = memberService.getById(memberId);
+        deviceTokenService.deleteToken(member, deviceId);
     }
 
 }

--- a/jabiseo-api/src/main/java/com/jabiseo/api/auth/application/usecase/LogoutUseCase.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/api/auth/application/usecase/LogoutUseCase.java
@@ -1,5 +1,7 @@
 package com.jabiseo.api.auth.application.usecase;
 
+import com.jabiseo.domain.auth.domain.Auth;
+import com.jabiseo.domain.auth.domain.AuthService;
 import com.jabiseo.infra.cache.RedisCacheRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -10,10 +12,10 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class LogoutUseCase {
 
-    private final RedisCacheRepository redisCacheRepository;
+    private final AuthService authService;
 
-    public void execute(Long memberId) {
-        redisCacheRepository.deleteToken(memberId);
+    public void execute(Long memberId, String deviceId) {
+        authService.logout(Auth.create(deviceId, memberId, null));
     }
 
 }

--- a/jabiseo-api/src/main/java/com/jabiseo/api/auth/application/usecase/ReissueUseCase.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/api/auth/application/usecase/ReissueUseCase.java
@@ -3,11 +3,10 @@ package com.jabiseo.api.auth.application.usecase;
 import com.jabiseo.api.auth.application.JwtHandler;
 import com.jabiseo.api.auth.dto.ReissueRequest;
 import com.jabiseo.api.auth.dto.ReissueResponse;
-import com.jabiseo.domain.auth.exception.AuthenticationBusinessException;
-import com.jabiseo.domain.auth.exception.AuthenticationErrorCode;
+import com.jabiseo.domain.auth.domain.Auth;
+import com.jabiseo.domain.auth.domain.AuthService;
 import com.jabiseo.domain.member.domain.Member;
 import com.jabiseo.domain.member.service.MemberService;
-import com.jabiseo.infra.cache.RedisCacheRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,20 +17,14 @@ import org.springframework.transaction.annotation.Transactional;
 public class ReissueUseCase {
 
     private final MemberService memberService;
-    private final RedisCacheRepository redisCacheRepository;
+    private final AuthService authService;
     private final JwtHandler jwtHandler;
 
-    public ReissueResponse execute(ReissueRequest request, Long memberId) {
+    public ReissueResponse execute(ReissueRequest request, Long memberId, String deviceId) {
         Member member = memberService.getById(memberId);
 
         jwtHandler.validateRefreshToken(request.refreshToken());
-
-        String savedToken = redisCacheRepository.findToken(memberId)
-                .orElseThrow(() -> new AuthenticationBusinessException(AuthenticationErrorCode.REQUIRE_LOGIN));
-
-        if (!savedToken.equals(request.refreshToken())) {
-            throw new AuthenticationBusinessException(AuthenticationErrorCode.NOT_MATCH_REFRESH);
-        }
+        authService.reissue(Auth.create(deviceId, member.getId(), request.refreshToken()));
 
         String accessToken = jwtHandler.createAccessToken(member);
         return new ReissueResponse(accessToken);

--- a/jabiseo-api/src/main/java/com/jabiseo/api/auth/controller/AuthController.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/api/auth/controller/AuthController.java
@@ -10,6 +10,8 @@ import com.jabiseo.api.auth.application.usecase.ReissueUseCase;
 import com.jabiseo.api.auth.application.usecase.WithdrawUseCase;
 import com.jabiseo.api.config.auth.AuthMember;
 import com.jabiseo.api.config.auth.AuthenticatedMember;
+import com.jabiseo.api.config.deviceinfo.DeviceInfo;
+import com.jabiseo.api.config.deviceinfo.RequestDeviceInfo;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -33,26 +35,29 @@ public class AuthController {
 
     @PostMapping("/login")
     public ResponseEntity<LoginResponse> login(
-            @Valid @RequestBody LoginRequest loginRequest
+            @Valid @RequestBody LoginRequest loginRequest,
+            @RequestDeviceInfo DeviceInfo deviceInfo
     ) {
-        LoginResponse result = loginUseCase.execute(loginRequest);
+        LoginResponse result = loginUseCase.execute(loginRequest, deviceInfo.getDeviceId());
         return ResponseEntity.ok(result);
     }
 
     @PostMapping("/reissue")
     public ResponseEntity<ReissueResponse> reissue(
             @Valid @RequestBody ReissueRequest request,
-            @AuthenticatedMember AuthMember member
+            @AuthenticatedMember AuthMember member,
+            @RequestDeviceInfo DeviceInfo deviceInfo
     ) {
-        ReissueResponse result = reissueUseCase.execute(request, member.getMemberId());
+        ReissueResponse result = reissueUseCase.execute(request, member.getMemberId(), deviceInfo.getDeviceId());
         return ResponseEntity.ok(result);
     }
 
     @PostMapping("/logout")
     public ResponseEntity<Void> logout(
-            @AuthenticatedMember AuthMember member
+            @AuthenticatedMember AuthMember member,
+            @RequestDeviceInfo DeviceInfo deviceInfo
     ) {
-        logoutUseCase.execute(member.getMemberId());
+        logoutUseCase.execute(member.getMemberId(), deviceInfo.getDeviceId());
         return ResponseEntity.noContent().build();
     }
 

--- a/jabiseo-api/src/main/java/com/jabiseo/api/auth/controller/DevAuthController.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/api/auth/controller/DevAuthController.java
@@ -7,7 +7,6 @@ import com.jabiseo.api.config.deviceinfo.RequestDeviceInfo;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
-import org.springframework.core.env.Environment;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -18,17 +17,15 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api")
 public class DevAuthController {
 
-    private final Environment environment;
     private final DevLoginHelper loginHelper;
-    private static final String LIMIT_PROFILE = "local";
 
     @GetMapping("/dev/auth")
     public ResponseEntity<?> devAuth(
             @RequestParam(value = "member-id") @NotBlank String memberId,
-            @RequestDeviceInfo DeviceInfo info
+            @RequestDeviceInfo DeviceInfo deviceInfo
     ) {
 
-        LoginResponse result = loginHelper.login(Long.parseLong(memberId));
+        LoginResponse result = loginHelper.login(Long.parseLong(memberId), deviceInfo.getDeviceId());
         return ResponseEntity.ok(result);
     }
 

--- a/jabiseo-api/src/main/java/com/jabiseo/api/auth/controller/DevAuthController.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/api/auth/controller/DevAuthController.java
@@ -22,10 +22,11 @@ public class DevAuthController {
     @GetMapping("/dev/auth")
     public ResponseEntity<?> devAuth(
             @RequestParam(value = "member-id") @NotBlank String memberId,
+            @RequestParam(value = "fcm-token", required = false) String token,
             @RequestDeviceInfo DeviceInfo deviceInfo
     ) {
 
-        LoginResponse result = loginHelper.login(Long.parseLong(memberId), deviceInfo.getDeviceId());
+        LoginResponse result = loginHelper.login(Long.parseLong(memberId), deviceInfo.getDeviceId(), token);
         return ResponseEntity.ok(result);
     }
 

--- a/jabiseo-api/src/main/java/com/jabiseo/api/auth/controller/DevAuthController.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/api/auth/controller/DevAuthController.java
@@ -2,6 +2,8 @@ package com.jabiseo.api.auth.controller;
 
 import com.jabiseo.api.auth.application.DevLoginHelper;
 import com.jabiseo.api.auth.dto.LoginResponse;
+import com.jabiseo.api.config.deviceinfo.DeviceInfo;
+import com.jabiseo.api.config.deviceinfo.RequestDeviceInfo;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
@@ -22,7 +24,8 @@ public class DevAuthController {
 
     @GetMapping("/dev/auth")
     public ResponseEntity<?> devAuth(
-            @RequestParam(value = "member-id") @NotBlank String memberId
+            @RequestParam(value = "member-id") @NotBlank String memberId,
+            @RequestDeviceInfo DeviceInfo info
     ) {
 
         LoginResponse result = loginHelper.login(Long.parseLong(memberId));

--- a/jabiseo-api/src/main/java/com/jabiseo/api/auth/dto/LoginRequest.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/api/auth/dto/LoginRequest.java
@@ -8,6 +8,7 @@ public record LoginRequest(
         @NotNull
         String idToken,
         @EnumValid(enumClass = OauthServer.class, message = "oauthServer Type이 올바르지 않습니다.")
-        String oauthServer
+        String oauthServer,
+        String fcmToken
 ) {
 }

--- a/jabiseo-api/src/main/java/com/jabiseo/api/config/WebConfig.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/api/config/WebConfig.java
@@ -1,6 +1,7 @@
 package com.jabiseo.api.config;
 
 import com.jabiseo.api.config.auth.AuthenticatedMemberArgumentResolver;
+import com.jabiseo.api.config.deviceinfo.RequestDeviceInfoArgumentResolver;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
@@ -27,8 +28,15 @@ public class WebConfig implements WebMvcConfigurer {
         return new AuthenticatedMemberArgumentResolver();
     }
 
+    @Bean
+    HandlerMethodArgumentResolver requestDeviceInfoArgumentResolver() {
+        return new RequestDeviceInfoArgumentResolver();
+    }
+
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(authenticatedMemberArgumentResolver());
+        resolvers.add(requestDeviceInfoArgumentResolver());
     }
+
 }

--- a/jabiseo-api/src/main/java/com/jabiseo/api/config/deviceinfo/DeviceInfo.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/api/config/deviceinfo/DeviceInfo.java
@@ -1,0 +1,13 @@
+package com.jabiseo.api.config.deviceinfo;
+
+import lombok.Getter;
+
+@Getter
+public class DeviceInfo {
+
+    private String deviceId;
+
+    public DeviceInfo(String deviceId) {
+        this.deviceId = deviceId;
+    }
+}

--- a/jabiseo-api/src/main/java/com/jabiseo/api/config/deviceinfo/RequestDeviceInfo.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/api/config/deviceinfo/RequestDeviceInfo.java
@@ -1,0 +1,12 @@
+package com.jabiseo.api.config.deviceinfo;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RequestDeviceInfo {
+
+}

--- a/jabiseo-api/src/main/java/com/jabiseo/api/config/deviceinfo/RequestDeviceInfoArgumentResolver.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/api/config/deviceinfo/RequestDeviceInfoArgumentResolver.java
@@ -1,0 +1,35 @@
+package com.jabiseo.api.config.deviceinfo;
+
+import com.jabiseo.domain.common.exception.BusinessException;
+import com.jabiseo.domain.common.exception.CommonErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Slf4j
+public class RequestDeviceInfoArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private static final String DEVICE_ID_HEADER = "X-Device-Id";
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        boolean isRequestDeviceInfoAnnotation = parameter.getParameterAnnotation(RequestDeviceInfo.class) != null;
+        boolean isDeviceInfoClass = parameter.getParameterType().equals(DeviceInfo.class);
+        return isRequestDeviceInfoAnnotation && isDeviceInfoClass;
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        String deviceId = webRequest.getHeader(DEVICE_ID_HEADER);
+
+        if(deviceId == null) {
+            log.warn("Request device id is empty");
+            throw new BusinessException(CommonErrorCode.INVALID_REQUEST_PARAMETER);
+        }
+
+        return new DeviceInfo(deviceId);
+    }
+}

--- a/jabiseo-api/src/main/java/com/jabiseo/api/config/deviceinfo/RequestDeviceInfoArgumentResolver.java
+++ b/jabiseo-api/src/main/java/com/jabiseo/api/config/deviceinfo/RequestDeviceInfoArgumentResolver.java
@@ -27,7 +27,7 @@ public class RequestDeviceInfoArgumentResolver implements HandlerMethodArgumentR
 
         if(deviceId == null) {
             log.warn("Request device id is empty");
-            throw new BusinessException(CommonErrorCode.INVALID_REQUEST_PARAMETER);
+            throw new BusinessException(CommonErrorCode.INVALID_REQUEST_HEADER);
         }
 
         return new DeviceInfo(deviceId);

--- a/jabiseo-api/src/test/java/com/jabiseo/api/auth/application/usecase/LoginUseCaseTest.java
+++ b/jabiseo-api/src/test/java/com/jabiseo/api/auth/application/usecase/LoginUseCaseTest.java
@@ -9,6 +9,7 @@ import com.jabiseo.domain.auth.domain.AuthService;
 import com.jabiseo.domain.member.domain.Member;
 import com.jabiseo.domain.member.domain.OauthMemberInfo;
 import com.jabiseo.domain.member.domain.OauthServer;
+import com.jabiseo.domain.member.service.DeviceTokenService;
 import com.jabiseo.domain.member.service.MemberService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -41,12 +42,15 @@ class LoginUseCaseTest {
 
     @Mock
     MemberService memberService;
+    @Mock
+    DeviceTokenService deviceTokenService;
+
 
     @Test
     @DisplayName("로그인 이후 Jwt를 발급 및 저장한다.")
     void loginSuccessCreateJwtAndSave() throws Exception {
         //given
-        LoginRequest request = new LoginRequest("idToken", "KAKAO");
+        LoginRequest request = new LoginRequest("idToken", "KAKAO", "token");
         OauthMemberInfo memberInfo = new OauthMemberInfo("id", OauthServer.KAKAO, "email@emil.com");
         Member member = createMember(1L);
         String access = "access";
@@ -64,5 +68,6 @@ class LoginUseCaseTest {
         assertThat(result.accessToken()).isEqualTo(access);
         assertThat(result.refreshToken()).isEqualTo(refresh);
         verify(authService, times(1)).login(Auth.create(deviceId, member.getId(), refresh));
+        verify(deviceTokenService, times(1)).loginToken(member, request.fcmToken(), deviceId);
     }
 }

--- a/jabiseo-api/src/test/java/com/jabiseo/api/auth/dto/LoginRequestTest.java
+++ b/jabiseo-api/src/test/java/com/jabiseo/api/auth/dto/LoginRequestTest.java
@@ -1,6 +1,5 @@
 package com.jabiseo.api.auth.dto;
 
-import com.jabiseo.api.auth.dto.LoginRequest;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
@@ -34,7 +33,8 @@ class LoginRequestTest {
         //given
         String idToken = null;
         String oauthServer = null;
-        LoginRequest loginRequest = new LoginRequest(idToken, oauthServer);
+        String fcmToken = null;
+        LoginRequest loginRequest = new LoginRequest(idToken, oauthServer, fcmToken);
 
         //when
         Set<ConstraintViolation<LoginRequest>> violations = validator.validate(loginRequest);
@@ -48,7 +48,8 @@ class LoginRequestTest {
     @ValueSource(strings = {"kakao", "kakakkao", "", "value", "ggogo", "KAKAOOO"})
     void oauthServerNotAllowInputsThrowException(String oauthServer) {
         String idToken = "IdTokens..";
-        LoginRequest loginRequest = new LoginRequest(idToken, oauthServer);
+        String fcmToken = null;
+        LoginRequest loginRequest = new LoginRequest(idToken, oauthServer, fcmToken);
 
         //when
         Set<ConstraintViolation<LoginRequest>> violations = validator.validate(loginRequest);
@@ -63,7 +64,9 @@ class LoginRequestTest {
     void LoginRequestSuccess(String oauthServer) {
         //given
         String idToken = "IdTokens..";
-        LoginRequest loginRequest = new LoginRequest(idToken, oauthServer);
+
+        String fcmToken = "fcmToken";
+        LoginRequest loginRequest = new LoginRequest(idToken, oauthServer, fcmToken);
 
         //when
         Set<ConstraintViolation<LoginRequest>> violations = validator.validate(loginRequest);

--- a/jabiseo-domain/src/main/java/com/jabiseo/domain/auth/domain/Auth.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/domain/auth/domain/Auth.java
@@ -1,0 +1,47 @@
+package com.jabiseo.domain.auth.domain;
+
+import com.jabiseo.domain.auth.exception.AuthenticationBusinessException;
+import com.jabiseo.domain.auth.exception.AuthenticationErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Objects;
+
+@Getter
+@AllArgsConstructor
+public class Auth {
+    private static final String PREFIX = "AUTH";
+    private String deviceId;
+    private Long memberId;
+    private String tokenValue;
+
+
+    public String getAuthKey() {
+        return PREFIX + "_" + memberId + "_" + deviceId;
+    }
+
+    public static Auth create(String deviceId, Long memberId, String tokenValue) {
+        return new Auth(deviceId, memberId, tokenValue);
+    }
+
+    public void checkAuthToken(String token) {
+        if (!tokenValue.equals(token)) {
+            throw new AuthenticationBusinessException(AuthenticationErrorCode.NOT_MATCH_REFRESH);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Auth auth = (Auth) o;
+        return Objects.equals(deviceId, auth.deviceId) &&
+                Objects.equals(memberId, auth.memberId) &&
+                Objects.equals(tokenValue, auth.tokenValue);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(deviceId, memberId, tokenValue);
+    }
+}

--- a/jabiseo-domain/src/main/java/com/jabiseo/domain/auth/domain/AuthRepository.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/domain/auth/domain/AuthRepository.java
@@ -1,0 +1,13 @@
+package com.jabiseo.domain.auth.domain;
+
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+public interface AuthRepository {
+
+    void saveAuth(Auth auth);
+    Optional<Auth> getSavedAuth(Auth authKey);
+    void deleteAuth(String authKey);
+}

--- a/jabiseo-domain/src/main/java/com/jabiseo/domain/auth/domain/AuthService.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/domain/auth/domain/AuthService.java
@@ -1,0 +1,32 @@
+package com.jabiseo.domain.auth.domain;
+
+import com.jabiseo.domain.auth.exception.AuthenticationBusinessException;
+import com.jabiseo.domain.auth.exception.AuthenticationErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final AuthRepository authRepository;
+
+    public void login(Auth auth) {
+        authRepository.saveAuth(auth);
+    }
+
+    public void reissue(Auth auth) {
+        Auth savedAuth = authRepository.getSavedAuth(auth)
+                .orElseThrow(() -> new AuthenticationBusinessException(AuthenticationErrorCode.REQUIRE_LOGIN));
+
+        savedAuth.checkAuthToken(auth.getTokenValue());
+    }
+
+
+    public void logout(Auth auth) {
+        authRepository.deleteAuth(auth.getAuthKey());
+    }
+
+}

--- a/jabiseo-domain/src/main/java/com/jabiseo/domain/common/exception/CommonErrorCode.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/domain/common/exception/CommonErrorCode.java
@@ -9,7 +9,8 @@ public enum CommonErrorCode implements ErrorCode {
     INTERNAL_SERVER_ERROR("internal server error", "COM_002", ErrorCode.INTERNAL_SERVER_ERROR),
     INVALID_REQUEST_PARAMETER("요청의 parameter가 올바르지 않습니다.", "COM_003", ErrorCode.BAD_REQUEST),
     FORBIDDEN("권한이 없거나 금지된 요청입니다.", "COM_004", ErrorCode.FORBIDDEN),
-    NOT_FOUND("리소스를 찾을 수 없습니다", "COM_005", ErrorCode.NOT_FOUND);
+    NOT_FOUND("리소스를 찾을 수 없습니다", "COM_005", ErrorCode.NOT_FOUND),
+    INVALID_REQUEST_HEADER("요청 헤더가 올바르지 않습니다.", "COM_006", ErrorCode.BAD_REQUEST);
 
     private final String message;
     private final String errorCode;

--- a/jabiseo-domain/src/main/java/com/jabiseo/domain/member/domain/DeviceToken.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/domain/member/domain/DeviceToken.java
@@ -1,0 +1,55 @@
+package com.jabiseo.domain.member.domain;
+
+import io.hypersistence.utils.hibernate.id.Tsid;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DeviceToken {
+    @Id
+    @Tsid
+    @Column(name = "device_token_id")
+    private Long id;
+
+    private String deviceId;
+
+    private String token;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
+    private Member member;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedAt;
+
+    public DeviceToken(String deviceId, String token, Member member) {
+        this.deviceId = deviceId;
+        this.token = token;
+        this.member = member;
+    }
+
+    public static DeviceToken create(String deviceId, String token, Member member) {
+        return new DeviceToken(deviceId, token, member);
+    }
+
+    public void updateToken(String token){
+        this.token = token;
+    }
+
+
+}

--- a/jabiseo-domain/src/main/java/com/jabiseo/domain/member/domain/DeviceToken.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/domain/member/domain/DeviceToken.java
@@ -5,7 +5,6 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;

--- a/jabiseo-domain/src/main/java/com/jabiseo/domain/member/domain/DeviceTokenRepository.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/domain/member/domain/DeviceTokenRepository.java
@@ -1,0 +1,12 @@
+package com.jabiseo.domain.member.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface DeviceTokenRepository extends JpaRepository<DeviceToken, Long> {
+
+    Optional<DeviceToken> findByMemberAndDeviceId(Member member, String deviceId);
+
+    void deleteByMemberAndDeviceId(Member member, String deviceId);
+}

--- a/jabiseo-domain/src/main/java/com/jabiseo/domain/member/service/DeviceTokenService.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/domain/member/service/DeviceTokenService.java
@@ -1,0 +1,34 @@
+package com.jabiseo.domain.member.service;
+
+import com.jabiseo.domain.member.domain.DeviceToken;
+import com.jabiseo.domain.member.domain.DeviceTokenRepository;
+import com.jabiseo.domain.member.domain.Member;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class DeviceTokenService {
+
+    private final DeviceTokenRepository deviceTokenRepository;
+
+    public void loginToken(Member member, String token, String deviceId) {
+        if (token == null) {
+            return;
+        }
+
+        DeviceToken deviceToken = deviceTokenRepository.findByMemberAndDeviceId(member, deviceId)
+                .orElseGet(() -> {
+                    DeviceToken newToken = DeviceToken.create(deviceId, token, member);
+                    return deviceTokenRepository.save(newToken);
+                });
+
+        deviceToken.updateToken(token);
+    }
+
+    public void deleteToken(Member member, String deviceId) {
+        deviceTokenRepository.deleteByMemberAndDeviceId(member, deviceId);
+    }
+}

--- a/jabiseo-domain/src/test/java/com/jabiseo/domain/auth/domain/AuthServiceTest.java
+++ b/jabiseo-domain/src/test/java/com/jabiseo/domain/auth/domain/AuthServiceTest.java
@@ -1,0 +1,90 @@
+package com.jabiseo.domain.auth.domain;
+
+import com.jabiseo.domain.auth.exception.AuthenticationBusinessException;
+import com.jabiseo.domain.auth.exception.AuthenticationErrorCode;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AuthService 테스트")
+class AuthServiceTest {
+
+    @InjectMocks
+    AuthService authService;
+
+    @Mock
+    AuthRepository authRepository;
+
+    Auth requestAuth;
+
+    @BeforeEach
+    void setUp() {
+        String requestDeviceId = "deviceId";
+        Long requestMemberId = 1L;
+        String requestTokenValue = "tokens";
+        requestAuth = Auth.create(requestDeviceId, requestMemberId, requestTokenValue);
+    }
+
+    @Test
+    @DisplayName("로그인 성공시 인증 정보를 저장한다.")
+    void loginSuccess() {
+        //given
+        //when
+        authService.login(requestAuth);
+
+        //then
+        verify(authRepository, times(1)).saveAuth(requestAuth);
+    }
+
+    @Test
+    @DisplayName("재발급 요청시 저장된 인증 정보가 없다면 예외를 반환한다.")
+    void isNotSaveAuthThrowException() {
+        //given
+        given(authRepository.getSavedAuth(requestAuth)).willReturn(Optional.empty());
+
+        // when then
+        Assertions.assertThatThrownBy(() -> authService.reissue(requestAuth))
+                .isInstanceOf(AuthenticationBusinessException.class)
+                .hasMessageContaining(AuthenticationErrorCode.REQUIRE_LOGIN.getMessage());
+    }
+
+
+    @Test
+    @DisplayName("재발급 요청시 저장된 인증 정보가 있으면 확인을 수행한다.")
+    void isSaveAuthCallingCheckMethod() {
+        //given
+        Auth savedAuth = spy(Auth.create(requestAuth.getDeviceId(), requestAuth.getMemberId(), requestAuth.getTokenValue()));
+
+        given(authRepository.getSavedAuth(requestAuth)).willReturn(Optional.of(savedAuth));
+
+        // when
+        authService.reissue(requestAuth);
+
+        //then
+        verify(savedAuth, times(1)).checkAuthToken(requestAuth.getTokenValue());
+    }
+
+    @Test
+    @DisplayName("로그아웃 요청시 저장된 인증정보를 삭제한다.")
+    void logoutSuccessCallDeleteMethod(){
+        //given
+        //when
+        authService.logout(requestAuth);
+
+        //then
+        verify(authRepository, times(1)).deleteAuth(requestAuth.getAuthKey());
+    }
+
+
+}

--- a/jabiseo-domain/src/test/java/com/jabiseo/domain/auth/domain/AuthTest.java
+++ b/jabiseo-domain/src/test/java/com/jabiseo/domain/auth/domain/AuthTest.java
@@ -1,0 +1,50 @@
+package com.jabiseo.domain.auth.domain;
+
+import com.jabiseo.domain.auth.exception.AuthenticationBusinessException;
+import com.jabiseo.domain.auth.exception.AuthenticationErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("Auth 엔티티 테스트")
+class AuthTest {
+
+
+    @Test
+    @DisplayName("key 요청시 memberId와 deviceId가 포함된 올바른 Key값을 리턴한다")
+    void getKeySuccess(){
+        //given
+        Long memberId = 1L;
+        String deviceId = "deviceId";
+        String token = "tokens..";
+        Auth auth = Auth.create(deviceId, memberId, token);
+
+        //when
+        String expectedAuthKey = "AUTH_1_deviceId";
+        String authKey = auth.getAuthKey();
+
+        //then
+        assertThat(authKey).isEqualTo(expectedAuthKey);
+    }
+
+    @Test
+    @DisplayName("Auth 객체의 TokenValue 값과 일치하지 않는 경우 예외를 반환한다.")
+    void checkAuthTokenFailThrownException(){
+        //given
+        Long memberId = 1L;
+        String deviceId = "deviceId";
+        String token = "tokens..";
+        Auth auth = Auth.create(deviceId, memberId, token);
+
+        //when
+        String notMatchToken = "Token";
+
+        //then
+        assertThatThrownBy(()-> auth.checkAuthToken(notMatchToken))
+                .isInstanceOf(AuthenticationBusinessException.class)
+                .hasMessage(AuthenticationErrorCode.NOT_MATCH_REFRESH.getMessage());
+    }
+}

--- a/jabiseo-domain/src/test/java/com/jabiseo/domain/member/service/DeviceTokenServiceTest.java
+++ b/jabiseo-domain/src/test/java/com/jabiseo/domain/member/service/DeviceTokenServiceTest.java
@@ -1,0 +1,59 @@
+package com.jabiseo.domain.member.service;
+
+import com.jabiseo.domain.member.domain.DeviceToken;
+import com.jabiseo.domain.member.domain.DeviceTokenRepository;
+import com.jabiseo.domain.member.domain.Member;
+import fixture.MemberFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("deviceTokenService 테스트")
+class DeviceTokenServiceTest {
+
+    @InjectMocks
+    DeviceTokenService deviceTokenService;
+
+    @Mock
+    DeviceTokenRepository deviceTokenRepository;
+
+    Member member = MemberFixture.createMember(1L);
+    String deviceId = "1";
+
+    @Test
+    @DisplayName("login token 요청시 token 값이 null이면 수행하지 않는다.")
+    void tokenIsNullNotAction() {
+        //given
+        String token = null;
+
+        //when
+        deviceTokenService.loginToken(member, token, deviceId);
+
+        //then
+        verify(deviceTokenRepository, times(0)).findByMemberAndDeviceId(member, deviceId);
+    }
+
+    @Test
+    @DisplayName("loginToken 요청시 값이 저장되있지 않다면 새 값을 생성해 저장한다.")
+    void isNotSaveTokenThenCreateNewToken() {
+        //given
+        String token = "token";
+        DeviceToken deviceToken = spy(DeviceToken.create(deviceId, token, member));
+        given(deviceTokenRepository.findByMemberAndDeviceId(member, deviceId)).willReturn(Optional.of(deviceToken));
+        //when
+        deviceTokenService.loginToken(member, token, deviceId);
+
+        //then
+        verify(deviceTokenRepository, times(1)).findByMemberAndDeviceId(member, deviceId);
+        verify(deviceToken, times(1)).updateToken(token);
+    }
+}

--- a/jabiseo-domain/src/test/java/com/jabiseo/domain/plan/service/PlanProgressServiceTest.java
+++ b/jabiseo-domain/src/test/java/com/jabiseo/domain/plan/service/PlanProgressServiceTest.java
@@ -98,7 +98,6 @@ class PlanProgressServiceTest {
         verify(planProgressRepository, times(1)).saveAll(any());
     }
 
-    //TODO: 해결해야 함
     @Test
     @DisplayName("calculateProgress 메소드 progress 계산 로직 테스트")
     void calculateProgressTest() {

--- a/jabiseo-domain/src/test/java/com/jabiseo/domain/plan/service/PlanProgressServiceTest.java
+++ b/jabiseo-domain/src/test/java/com/jabiseo/domain/plan/service/PlanProgressServiceTest.java
@@ -113,32 +113,32 @@ class PlanProgressServiceTest {
 
 
         //when
-//        List<PlanProgress> result = planProgressService.calculateProgress(planProgresses, datas);
-//
-//        //then
-//        result.forEach((planProgress -> {
-//            long expectedValue = -1;
-//            if (planProgress.getActivityType().equals(ActivityType.EXAM)) {
-//                expectedValue = datas.stream()
-//                        .filter(pi -> pi.getMode().equals(LearningMode.EXAM))
-//                        .count();
-//            }
-//            if (planProgress.getActivityType().equals(ActivityType.STUDY)) {
-//                expectedValue = datas.stream()
-//                        .filter(pi -> pi.getMode().equals(LearningMode.STUDY))
-//                        .count();
-//            }
-//            if (planProgress.getActivityType().equals(ActivityType.PROBLEM)) {
-//                expectedValue = datas.stream()
-//                        .mapToLong(LearningWithSolvingCountQueryDto::getSolvingCount).sum();
-//            }
-//            if (planProgress.getActivityType().equals(ActivityType.TIME)) {
-//                expectedValue = datas.stream()
-//                        .mapToLong(LearningWithSolvingCountQueryDto::getLearningTime).sum();
-//            }
-//
-//            assertThat(planProgress.getCompletedValue()).isEqualTo(expectedValue);
-//        }));
+        List<PlanProgress> result = planProgressService.calculateProgress(planProgresses, datas);
+
+        //then
+        result.forEach((planProgress -> {
+            long expectedValue = -1;
+            if (planProgress.getActivityType().equals(ActivityType.EXAM)) {
+                expectedValue = datas.stream()
+                        .filter(pi -> pi.getMode().equals(LearningMode.EXAM))
+                        .count();
+            }
+            if (planProgress.getActivityType().equals(ActivityType.STUDY)) {
+                expectedValue = datas.stream()
+                        .filter(pi -> pi.getMode().equals(LearningMode.STUDY))
+                        .count();
+            }
+            if (planProgress.getActivityType().equals(ActivityType.PROBLEM)) {
+                expectedValue = datas.stream()
+                        .mapToLong(LearningWithSolvingCountQueryDto::getSolvingCount).sum();
+            }
+            if (planProgress.getActivityType().equals(ActivityType.TIME)) {
+                expectedValue = datas.stream()
+                        .mapToLong(LearningWithSolvingCountQueryDto::getLearningTime).sum();
+            }
+
+            assertThat(planProgress.getCompletedValue()).isEqualTo(expectedValue);
+        }));
 
     }
 

--- a/jabiseo-infrastructure/src/main/java/com/jabiseo/infra/cache/AuthRepositoryImpl.java
+++ b/jabiseo-infrastructure/src/main/java/com/jabiseo/infra/cache/AuthRepositoryImpl.java
@@ -1,0 +1,38 @@
+package com.jabiseo.infra.cache;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jabiseo.domain.auth.domain.Auth;
+import com.jabiseo.domain.auth.domain.AuthRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Slf4j
+@Component
+public class AuthRepositoryImpl implements AuthRepository {
+
+    private final ValueOperations<String, String> operation;
+
+    public AuthRepositoryImpl(RedisTemplate<String, String> redisStringTemplate) {
+        this.operation = redisStringTemplate.opsForValue();
+    }
+
+    @Override
+    public void saveAuth(Auth auth) {
+        operation.set(auth.getAuthKey(), auth.getTokenValue());
+    }
+
+    @Override
+    public Optional<Auth> getSavedAuth(Auth auth) {
+        return Optional.ofNullable(operation.get(auth.getAuthKey()))
+                .map(token -> Auth.create(auth.getDeviceId(), auth.getMemberId(), token));
+    }
+
+    @Override
+    public void deleteAuth(String authKey) {
+        operation.getAndDelete(authKey);
+    }
+}

--- a/jabiseo-infrastructure/src/main/java/com/jabiseo/infra/cache/RedisCacheRepository.java
+++ b/jabiseo-infrastructure/src/main/java/com/jabiseo/infra/cache/RedisCacheRepository.java
@@ -22,30 +22,11 @@ public class RedisCacheRepository {
 
     private final RedisTemplate<String, String> redisStringTemplate;
     private final ValueOperations<String, String> operation;
-    private static final String MEMBER_TOKEN_PREFIX = "member_token:";
     private final ObjectMapper mapper = new ObjectMapper();
 
     public RedisCacheRepository(RedisTemplate<String, String> redisStringTemplate) {
         this.redisStringTemplate = redisStringTemplate;
         this.operation = redisStringTemplate.opsForValue();
-    }
-
-
-    public void saveToken(Long memberId, String value) {
-        operation.set(toMemberTokenKey(memberId), value);
-    }
-
-    public Optional<String> findToken(Long memberId) {
-        String token = operation.get(toMemberTokenKey(memberId));
-        return Optional.ofNullable(token);
-    }
-
-    public void deleteToken(Long memberId) {
-        operation.getAndDelete(toMemberTokenKey(memberId));
-    }
-
-    private String toMemberTokenKey(Long id) {
-        return MEMBER_TOKEN_PREFIX + id.toString();
     }
 
     public void savePublicKey(String key, List<OidcPublicKey> publicKeys) {


### PR DESCRIPTION
## PR 변경된 내용
1. FCM 리프레시 로직을 수행할때 여러 디바이스 환경을 고려해야 한다.
2. 이를 위해 클라이언트와 합의 후 Header에 DeviceId를 동봉해 보내주기로 함
3. DeviceId와 MemberId로 Jwt Refresh Token의 저장소의 key값을 생성해 다중로그인을 구현함
4. 이후 FCM 리프레시 로직과, Auth쪽 리팩토링을 수행함

### HTTP Header에서  DeviceId 가져오는 로직 구현
현재까지 DeviceId가 필요한 API 목록 (아래는 필수 API 임)
- GET: /api/dev/auth (개발용 로그인)
- POST: /api/auth/login (로그인)
- POST: /api/auth/reissue (Token 재발급)
- POST: /api/auth/logout (로그아웃)

이를 위해 Header에서 DeviceId 가져오는 로직을 적용시 Controller에서 수행할 수 있지만 여러 클래스에 적용될 수 있다고 판단해 기존 AuthenticatedMember Annotation 처럼 새로운 클래스 생성 

<table>
  <tr>
    <td>Annotation name</td>
    <td>Class Type</td>
    <td>설명</td>
  </tr>
  <tr>
    <td>RequestDeviceInfo</td>
    <td>DeviceInfo</td>
    <td>HTTP Header에서 DeviceId 추출, 네이밍은 기존 Spring Annotation과 비슷하게 적용함
     Controller에서 적용할때 없으면 예외를 던짐
     </td>
  </tr>
</table>


> RequestDeviceInfo의 적용관련해서 -> AuthenticatedMember의 경우 익명 유저는 null로 리턴했지만 해당 클래스는 예외를 던진다.
"@RequestDeviceInfo" 자체가 검증의 역할도 수행

### 다중 로그인 구현
- MemberId + DeviceId로 Key를 생성해 디바이스별 로그인 수행

### FCM Token 리프레시
-  로그인시 Token 리프레시 / 로그아웃 시 삭제
- 테스트용 개발용 로그인은 RequestParm으로 적용됨
- 추가 테이블 생성
DeviceToken
<table>
  <tr>
    <td>컬럼</td>
    <td>Type</td>
    <td>설명</td>
  </tr>
  <tr>
    <td>device_token_id</td>
    <td>long</td>
    <td>PK 값</td>
  </tr>
  <tr>
    <td>deviceId</td>
    <td>String</td>
    <td>클라이언트가 준 Id값 </td>
  </tr>
  <tr>
    <td>token</td>
    <td>String</td>
    <td>FCM TOKEN</td>
  </tr>
  <tr>
    <td>meber_id</td>
    <td>long</td>
    <td>회원 FK</td>
  </tr>
  <tr>
    <td>created_at</td>
    <td>Date</td>
    <td>생성 시간</td>
  </tr>
  <tr>
    <td>modified_at</td>
    <td>Date</td>
    <td>수정 시간</td>
  </tr>
</table>

### Auth로직 Service쪽으로 일부 변경 
- JWT로직의 경우 기존 Application단에 유지
- 토큰이 일치하는지 확인허거나, 저장하거나 하는 로직을 AuthService에 구현, 테스트 코드 작성
- Auth 객체 생성(순수 자바 객체)
- Redis에 저장하는 값과 형태가 달라서 그냥 순수 객체로 유지했습니다 (Redis에는 Key:ValueString)으로 저장함 

## 참조
Closes #89 
