### PR TITLE
Feat(Member): 현재 자격증이 없는 경우 멤버가 제대로 조회되지 않는 현상 수정

### DIFF
--- a/jabiseo-domain/src/main/java/com/jabiseo/domain/learning/domain/LearningRepository.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/domain/learning/domain/LearningRepository.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 public interface LearningRepository extends JpaRepository<Learning, Long>, LearningQueryDslRepository {
 
-    @Query("select l from Learning l join fetch l.problemSolvings where l.member = :member and l.createdAt between :startDateTime and :endDateTime")
+    @Query("SELECT l FROM Learning l JOIN FETCH l.problemSolvings WHERE l.member = :member AND l.createdAt BETWEEN :startDateTime AND :endDateTime")
     List<Learning> findByMemberAndCreatedAtBetweenWithProblemSolvings(Member member, LocalDateTime startDateTime, LocalDateTime endDateTime);
 
 }

--- a/jabiseo-domain/src/main/java/com/jabiseo/domain/member/domain/MemberRepository.java
+++ b/jabiseo-domain/src/main/java/com/jabiseo/domain/member/domain/MemberRepository.java
@@ -9,6 +9,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByOauthIdAndOauthServer(String oauthId, OauthServer oauthServer);
 
-    @Query("SELECT m FROM Member m JOIN FETCH m.currentCertificate WHERE m.id = :memberId")
+    @Query("SELECT m FROM Member m LEFT JOIN FETCH m.currentCertificate WHERE m.id = :memberId")
     Optional<Member> findByIdWithCertificate(Long memberId);
+
 }


### PR DESCRIPTION
## PR 변경된 내용
- 일부 상황에서 기존 쿼리는 다음과 같다.
```java
@Query("SELECT m FROM Member m JOIN FETCH m.currentCertificate WHERE m.id = :memberId")
```
currentCertificate가 null일 경우가 있을 수 있는데, 이 경우 오류가 발생하므로 다음과 같이 변경한다.
```java
@Query("SELECT m FROM Member m LEFT JOIN FETCH m.currentCertificate WHERE m.id = :memberId")
```

## 참조
